### PR TITLE
Docs: no need to setup SSH key for gitea

### DIFF
--- a/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
+++ b/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
@@ -41,7 +41,7 @@ If you are not already using Ubuntu 22.04, consider installing it on your system
   Those services host our Git software repositories.
 - Add your SSH key to GitHub to access and sync our repositories
     - If you don't know what I am talking about or you don't yet have a SSH key, follow this guide: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys
-    - Go to your account settings and add your SSH key (the ``.pub`` file) for `GitHub <https://github.com/settings/keys>`_ AND `Gitea <https://git.mafiasi.de/user/settings/keys>`_
+    - Go to your account settings and add your SSH key (the ``.pub`` file) to `GitHub <https://github.com/settings/keys>`_
 - Now, you can clone (download) our main code repository (repo) called `bitbots_main <https://github.com/bit-bots/bitbots_main>`_:
     - Open a terminal and go to the directory where you want to download our code (typically ``~/git/bitbots/``)
         - Create the directory with: ``mkdir -p ~/git/bitbots``


### PR DESCRIPTION
# Summary
Removes instruction to setup a SSH key for gitea, as we do not depend on any software from that service anymore.

## Proposed changes
Docs: no need to setup SSH key for gitea

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [ ] Run `colcon build`
- [X] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [X] This PR is on our `Software` project board
