### PR TITLE
Fix sync_includes_wolfgang_nuc.yaml bitbots_vision

### DIFF
--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -31,8 +31,7 @@ include:
         - bitbots_localization
         - bitbots_localization_handler
         - bitbots_path_planning
-    - bitbots_vision:
-        - bitbots_vision
+    - bitbots_vision
     - bitbots_wolfgang:
         - wolfgang_animations
         - wolfgang_description


### PR DESCRIPTION
# Summary
As the `bitbots_vision` package has now one directory nesting less, we need to adapt the sync_includes file.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [X] Test on the robot
- [X] This PR is on our `Software` project board
