### PR TITLE
Add git filter for selected lines in vscode config json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.vscode/settings.json filter=removeFullHomePath

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -194,8 +194,15 @@
     "ros.rosSetupScript": "${env:COLCON_WS}/install/setup.bash",
     "ros.distro": "iron",
     "search.useIgnoreFiles": false,
+    "python.autoComplete.extraPaths": [
+        // DO NOT COMMIT THESE ABSOLUTE PYTHON PATHS:
+        "/opt/ros/iron/lib/python3.10/site-packages"
+    ],
+    "python.analysis.extraPaths": [
+        // DO NOT COMMIT THESE ABSOLUTE PYTHON PATHS:
+        "/opt/ros/iron/lib/python3.10/site-packages"
+    ],
 
-    // DO NOT COMMIT THESE ABSOLUTE PYTHON PATHS:
-    
+
 
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -195,11 +195,9 @@
     "ros.distro": "iron",
     "search.useIgnoreFiles": false,
     "python.autoComplete.extraPaths": [
-        // DO NOT COMMIT THESE ABSOLUTE PYTHON PATHS:
         "/opt/ros/iron/lib/python3.10/site-packages"
     ],
     "python.analysis.extraPaths": [
-        // DO NOT COMMIT THESE ABSOLUTE PYTHON PATHS:
         "/opt/ros/iron/lib/python3.10/site-packages"
     ],
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -191,7 +191,6 @@
 
     // Tell the ROS extension where to find the setup.bash
     // This also utilizes the COLCON_WS environment variable, which needs to be set
-    "ros.rosSetupScript": "${env:COLCON_WS}/install/setup.bash",
     "ros.distro": "iron",
     "search.useIgnoreFiles": false,
     "python.autoComplete.extraPaths": [

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY : basler install install-no-root pip pre-commit format pull-all pull-init pull-repos pull-files fresh-libs remove-libs setup-libs rosdep status update update-no-root
+.PHONY : basler install install-no-root pip pre-commit install-git-filters format pull-all pull-init pull-repos pull-files fresh-libs remove-libs setup-libs rosdep status update update-no-root
 
 HTTPS := ""
 REPO:=$(dir $(abspath $(firstword $(MAKEFILE_LIST))))
@@ -18,6 +18,13 @@ pip:
 pre-commit:
 	# Install pre-commit hooks for all submodules that have a .pre-commit-config.yaml file
 	pre-commit install
+
+install-git-filters:
+	# Install git filters
+	# The vscode settings file gets updated by the ros extension and contains the full path to the current user's home directory.
+	# We don't want to commit this path, so we use a git filter to remove it when git adds the file to the staging area.
+	# This does not affect the file on disk, so vscode will still work as expected.
+	git config filter.removeFullHomePath.clean "sed '/\/home.*\(install\|build\)/d'"
 
 format:
 	# Format all files in the repository
@@ -78,6 +85,6 @@ status:
 	# Show status of all repositories
 	vcs status . --nested
 
-update: pull-all rosdep pip pre-commit
+update: pull-all rosdep pip install-git-filters pre-commit
 
-update-no-root: pull-all pip pre-commit
+update-no-root: pull-all pip install-git-filters pre-commit


### PR DESCRIPTION
# Summary
The VS Code ROS extension always adds a bunch of user specific absolute paths to the vscode settings json. This results in every user having uncommitted changes by default. Accidentally committing them is also annoying. We therefore add a rule to git that ignores said files.

## Proposed changes
- Add `.gitattributes` file that applies a custom filter on the settings file
- Add a custom filter rule that deletes lines containing absolute home directory paths from the given file.
- Install the custom filter with `update` make targets
- Also remove `ros.rosSetupScript` key from config as the extension did not work properly when is contained env variables, this was not an issue with previous versions of vscode. But it somehow discovers it without it in my version so I guess removing it is fine. Needs testing on other machine tho..