### PR TITLE
Use ruff format instead of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,7 @@ repos:
         args:
           - "--fix"
           - "--exit-non-zero-on-fix"
-  - repo: https://github.com/psf/black
-    rev: 23.10.0  # keep this version for Ubuntu support
-    hooks:
-      - id: black
+      - id: ruff-format
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5
     hooks:

--- a/bitbots_team_communication/scripts/team_comm_test_marker.py
+++ b/bitbots_team_communication/scripts/team_comm_test_marker.py
@@ -279,9 +279,7 @@ class TeamMessage:
                     ]
                     msg.ball_absolute = ball_absolute
 
-                    cartesian_distance = math.sqrt(
-                        ball_relative.pose.position.x**2 + ball_relative.pose.position.y**2
-                    )
+                    cartesian_distance = math.sqrt(ball_relative.pose.position.x**2 + ball_relative.pose.position.y**2)
                     msg.time_to_position_at_ball = cartesian_distance / ROBOT_SPEED
                 except tf2_ros.LookupException as ex:
                     self.get_logger().warn(self.get_name() + ": " + str(ex), throttle_duration_sec=10.0)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,5 @@
 # This file is used by pip to install dependencies for the development environment
 -r robot.txt  # Include robot.txt dependencies
-black  # Auto-formatting for python
 exhale  # Necessary for rst rendering
 fabric  # Manages SSH sessions for the deploy tool
 paramiko  # Necessary for fabric


### PR DESCRIPTION
# Summary
ruff comes with black formatting out of the box so we can just use it.
It is also a bit faster and has less deps.

## Proposed changes
- Remove black
- Change precommit config