### PR TITLE
Set autoDocstring vscode extension to not insert types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-    "autoDocstring.docstringFormat": "sphinx",
+    "autoDocstring.docstringFormat": "sphinx-notypes",
+    "autoDocstring.startOnNewLine": true,
     "cSpell.language": "en,de-de,lorem",
     "cSpell.words": [
         "ansible",


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
Set autoDocstring vscode extension to not insert types

## Proposed changes
<!--- Describe your changes and why they are necessary. -->
This is done, as we generally want to use python typing and including the type in the docstring too is unnecessary duplication of that information which is outdated fast.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [X] This PR is on our `Software` project board
