### PR TITLE
Remove robot controllers

### DIFF
--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -56,7 +56,6 @@ include:
         - ipm
         - particle_filter
         - pylon-ros-camera
-        - robot_controllers
         - ros2_numpy
         - ros2_python_extension
         - soccer_ipm

--- a/workspace.repos
+++ b/workspace.repos
@@ -62,10 +62,6 @@ repositories:
     type: git
     url: git@github.com:basler/pylon-ros-camera.git
     version: humble
-  lib/robot_controllers:
-    type: git
-    url: git@github.com:fetchrobotics/robot_controllers.git
-    version: ros2
   lib/ros2_numpy:
     type: git
     url: git@github.com:Bit-Bots/ros2_numpy.git


### PR DESCRIPTION
# Summary

The library is not used in the code at all. So I think it is not needed anymore. Also, it throws some warnings, is not maintained and throws warnings.

Accidentally based on #348. 