### PR TITLE
Fix stuck ssh deployment

### DIFF
--- a/scripts/deploy/tasks/sync.py
+++ b/scripts/deploy/tasks/sync.py
@@ -207,6 +207,8 @@ class Sync(AbstractTask):
                 "--checksum",
                 "--archive",
                 "--delete",
+                "-e",
+                '"ssh -o StrictHostKeyChecking=no"',
             ]
             if not be_quiet():
                 cmd.append("--verbose")


### PR DESCRIPTION
# Summary
The rsync command requires a manual 'yes' from the user upon first connection. This leads to the deploy tool getting stuck sometimes, as it calls rsync in the background. This should fix this issue, but it adds a slight security risk, which we accept for now.

## Proposed changes
- Ignore strict authentification for ssh in rsync