### PR TITLE
Wait for tf during robot startup

### DIFF
--- a/bitbots_misc/bitbots_utils/CMakeLists.txt
+++ b/bitbots_misc/bitbots_utils/CMakeLists.txt
@@ -20,7 +20,7 @@ enable_bitbots_docs()
 set(INCLUDE_DIRS include)
 include_directories(${INCLUDE_DIRS})
 
-add_compile_options(-Wall -Werror -Wno-unused -pedantic -Wextra)
+add_compile_options(-Wall -Werror -Wno-unused -pedantic -Wextra -fPIC)
 
 # Add cpp library
 add_library(${PROJECT_NAME} src/utils.cpp)

--- a/bitbots_misc/bitbots_utils/include/bitbots_utils/utils.hpp
+++ b/bitbots_misc/bitbots_utils/include/bitbots_utils/utils.hpp
@@ -25,7 +25,7 @@ namespace bitbots_utils {
  * @param verbose Can be used to disable the warning messages
  */
 void wait_for_tf(const rclcpp::Logger &logger, std::shared_ptr<rclcpp::Clock> clock,
-                 std::shared_ptr<tf2_ros::Buffer> tf_buffer, const std::vector<std::string> &frames,
+                 tf2_ros::Buffer* tf_buffer, const std::vector<std::string> &frames,
                  const std::string &root_frame, const rclcpp::Duration &check_interval = rclcpp::Duration(0.1s),
                  const rclcpp::Duration &warn_duration = rclcpp::Duration(5.0s),
                  const rclcpp::Duration &warn_interval = rclcpp::Duration(1.0s), bool verbose = true);

--- a/bitbots_misc/bitbots_utils/include/bitbots_utils/utils.hpp
+++ b/bitbots_misc/bitbots_utils/include/bitbots_utils/utils.hpp
@@ -24,9 +24,9 @@ namespace bitbots_utils {
  * @param warn_interval Interval in which to keep warning if the frames are not available
  * @param verbose Can be used to disable the warning messages
  */
-void wait_for_tf(const rclcpp::Logger &logger, std::shared_ptr<rclcpp::Clock> clock,
-                 tf2_ros::Buffer* tf_buffer, const std::vector<std::string> &frames,
-                 const std::string &root_frame, const rclcpp::Duration &check_interval = rclcpp::Duration(0.1s),
+void wait_for_tf(const rclcpp::Logger &logger, std::shared_ptr<rclcpp::Clock> clock, tf2_ros::Buffer *tf_buffer,
+                 const std::vector<std::string> &frames, const std::string &root_frame,
+                 const rclcpp::Duration &check_interval = rclcpp::Duration(0.1s),
                  const rclcpp::Duration &warn_duration = rclcpp::Duration(5.0s),
                  const rclcpp::Duration &warn_interval = rclcpp::Duration(1.0s), bool verbose = true);
 

--- a/bitbots_misc/bitbots_utils/src/utils.cpp
+++ b/bitbots_misc/bitbots_utils/src/utils.cpp
@@ -14,10 +14,10 @@ namespace bitbots_utils {
  * @param warn_interval Interval in which to keep warning if the frames are not available
  * @param verbose Can be used to disable the warning messages
  */
-void wait_for_tf(const rclcpp::Logger &logger, std::shared_ptr<rclcpp::Clock> clock,
-                 tf2_ros::Buffer* tf_buffer, const std::vector<std::string> &frames,
-                 const std::string &root_frame, const rclcpp::Duration &check_interval,
-                 const rclcpp::Duration &warn_duration, const rclcpp::Duration &warn_interval, bool verbose) {
+void wait_for_tf(const rclcpp::Logger &logger, std::shared_ptr<rclcpp::Clock> clock, tf2_ros::Buffer *tf_buffer,
+                 const std::vector<std::string> &frames, const std::string &root_frame,
+                 const rclcpp::Duration &check_interval, const rclcpp::Duration &warn_duration,
+                 const rclcpp::Duration &warn_interval, bool verbose) {
   // Store the beginning time
   auto start_time = clock->now();
 

--- a/bitbots_misc/bitbots_utils/src/utils.cpp
+++ b/bitbots_misc/bitbots_utils/src/utils.cpp
@@ -15,7 +15,7 @@ namespace bitbots_utils {
  * @param verbose Can be used to disable the warning messages
  */
 void wait_for_tf(const rclcpp::Logger &logger, std::shared_ptr<rclcpp::Clock> clock,
-                 std::shared_ptr<tf2_ros::Buffer> tf_buffer, const std::vector<std::string> &frames,
+                 tf2_ros::Buffer* tf_buffer, const std::vector<std::string> &frames,
                  const std::string &root_frame, const rclcpp::Duration &check_interval,
                  const rclcpp::Duration &warn_duration, const rclcpp::Duration &warn_interval, bool verbose) {
   // Store the beginning time

--- a/bitbots_motion/bitbots_dynup/CMakeLists.txt
+++ b/bitbots_motion/bitbots_dynup/CMakeLists.txt
@@ -10,8 +10,10 @@ set(PYBIND11_PYTHON_VERSION 3)
 set(PYBIND11_FINDPYTHON ON)
 
 find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(bitbots_msgs REQUIRED)
 find_package(bitbots_splines REQUIRED)
+find_package(bitbots_utils REQUIRED)
 find_package(control_msgs REQUIRED)
 find_package(control_toolbox REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -26,7 +28,6 @@ find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(backward_ros REQUIRED)
 
 find_package(ros2_python_extension REQUIRED)
 find_package(pybind11 REQUIRED)
@@ -51,6 +52,7 @@ ament_target_dependencies(
   ament_cmake
   bitbots_msgs
   bitbots_splines
+  bitbots_utils
   control_msgs
   control_toolbox
   geometry_msgs
@@ -79,6 +81,7 @@ ament_target_dependencies(
   ament_cmake
   bitbots_msgs
   bitbots_splines
+  bitbots_utils
   control_msgs
   control_toolbox
   geometry_msgs

--- a/bitbots_motion/bitbots_dynup/include/bitbots_dynup/dynup_node.hpp
+++ b/bitbots_motion/bitbots_dynup/include/bitbots_dynup/dynup_node.hpp
@@ -13,6 +13,7 @@
 
 #include <bitbots_dynup/msg/dynup_poses.hpp>
 #include <bitbots_msgs/msg/joint_command.hpp>
+#include <bitbots_utils/utils.hpp>
 #include <cmath>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>

--- a/bitbots_motion/bitbots_dynup/src/dynup_node.cpp
+++ b/bitbots_motion/bitbots_dynup/src/dynup_node.cpp
@@ -222,6 +222,11 @@ void DynupNode::execute(const std::shared_ptr<DynupGoalHandle> goal_handle) {
   reset();
   last_ros_update_time_ = 0;
   start_time_ = this->get_clock()->now().seconds();
+  
+  bitbots_utils::wait_for_tf(this->get_logger(), this->get_clock(), this->tf_buffer_.get(),
+                             {base_link_frame_, r_sole_frame_, l_sole_frame_, r_wrist_frame_, l_wrist_frame_},
+                             base_link_frame_);
+
   bitbots_dynup::msg::DynupPoses poses = getCurrentPoses();
   if (poses.header.stamp.nanosec != 0) {
     DynupRequest request;

--- a/bitbots_motion/bitbots_dynup/src/dynup_node.cpp
+++ b/bitbots_motion/bitbots_dynup/src/dynup_node.cpp
@@ -222,7 +222,7 @@ void DynupNode::execute(const std::shared_ptr<DynupGoalHandle> goal_handle) {
   reset();
   last_ros_update_time_ = 0;
   start_time_ = this->get_clock()->now().seconds();
-  
+
   bitbots_utils::wait_for_tf(this->get_logger(), this->get_clock(), this->tf_buffer_.get(),
                              {base_link_frame_, r_sole_frame_, l_sole_frame_, r_wrist_frame_, l_wrist_frame_},
                              base_link_frame_);

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm.dsd
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm.dsd
@@ -1,6 +1,6 @@
 -->HCM
 $StartHCM
-    START_UP --> @RobotStateStartup, @Wait + time:0.1 + r:false, @PlayAnimationDynup + direction:walkready, @Wait
+    START_UP --> @RobotStateStartup, @PlayAnimationDynup + direction:walkready
     RUNNING --> $Stop
         STOPPED --> @CancelGoals, @StopWalking, @PlayAnimationDynup + direction:walkready, @Wait
         FREE -->$RecordAnimation

--- a/bitbots_motion/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_motion/bitbots_odometry/src/motion_odometry.cpp
@@ -40,7 +40,7 @@ MotionOdometry::MotionOdometry() : Node("MotionOdometry"), param_listener_(get_n
 
 void MotionOdometry::loop() {
   // Wait for tf to be available
-  bitbots_utils::wait_for_tf(this->get_logger(), this->get_clock(), tf_buffer_,
+  bitbots_utils::wait_for_tf(this->get_logger(), this->get_clock(), tf_buffer_.get(),
                              {base_link_frame_, r_sole_frame_, l_sole_frame_}, base_link_frame_);
 
   rclcpp::Time cycle_start_time = this->now();

--- a/bitbots_motion/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_motion/bitbots_odometry/src/odometry_fuser.cpp
@@ -39,7 +39,7 @@ OdometryFuser::OdometryFuser()
 }
 
 void OdometryFuser::loop() {
-  bitbots_utils::wait_for_tf(this->get_logger(), this->get_clock(), this->tf_buffer_,
+  bitbots_utils::wait_for_tf(this->get_logger(), this->get_clock(), this->tf_buffer_.get(),
                              {base_link_frame_, r_sole_frame_, l_sole_frame_}, base_link_frame_);
 
   // get motion_odom transform


### PR DESCRIPTION
# Summary
The dynup sometimes failes to go into the inital walkready pose, because TF was not available yet. This fixes this by explicily waiting for TF to become available before the action is performed.

## Proposed changes
- Use wait for tf util used elsewhere
- Slightly adaüt it to handle unique pointer
- Make bitbots util library compatible with the dynup compiler flags
- Remove hardcoded wait from HCM

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [x] This PR is on our `Software` project board
