### PR TITLE
Create setup script for single command full dev setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,43 +1,43 @@
 {
-    "name": "Bit-Bots Iron Dev",
+  "name": "Bit-Bots Iron Dev",
 
-    "build": { "dockerfile": "Dockerfile" },
+  "build": { "dockerfile": "Dockerfile" },
 
-    "containerEnv": {
-      "DISPLAY": "${localEnv:DISPLAY}",
-      "LIBGL_ALWAYS_SOFTWARE": "1",
-      "QT_X11_NO_MITSHM": "1",
-      "DOCKER": "1"
-    },
+  "containerEnv": {
+    "DISPLAY": "${localEnv:DISPLAY}",
+    "LIBGL_ALWAYS_SOFTWARE": "1",
+    "QT_X11_NO_MITSHM": "1",
+    "DOCKER": "1"
+  },
 
-    "customizations": {
-        "vscode": {
-            "settings": {
-                "terminal.integrated.defaultProfile.linux": "zsh",
-                "terminal.integrated.profiles.linux": { "zsh": { "path": "/bin/zsh" } }
-            },
-            "extensions": [
-              "ms-iot.vscode-ros"
-            ]
-        }
-    },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": { "zsh": { "path": "/bin/zsh" } }
+      },
+      "extensions": ["ms-iot.vscode-ros"]
+    }
+  },
 
-    "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/root/colcon_ws/src/bitbots_main",
-    "workspaceFolder": "/root/colcon_ws/src/bitbots_main",
+  "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/root/colcon_ws/src/bitbots_main",
+  "workspaceFolder": "/root/colcon_ws/src/bitbots_main",
 
-    "mounts": [
-      "type=bind,source=${localEnv:HOME},target=/srv/host_home,consistency=cached",
-    ],
+  "mounts": [
+    "type=bind,source=${localEnv:HOME},target=/srv/host_home,consistency=cached"
+  ],
 
-    "runArgs": [
-      "--tmpfs", "/tmp:exec,mode=01777",
-      "--privileged",
-      "--net=host",
-      "--device=/dev/dri:/dev/dri",
-      "--volume=/tmp/.X11-unix:/tmp/.X11-unix",
-      "--cap-add=SYS_PTRACE",
-      "--security-opt", "seccomp=unconfined"
-    ],
+  "runArgs": [
+    "--tmpfs",
+    "/tmp:exec,mode=01777",
+    "--privileged",
+    "--net=host",
+    "--device=/dev/dri:/dev/dri",
+    "--volume=/tmp/.X11-unix:/tmp/.X11-unix",
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined"
+  ],
 
-    "postCreateCommand": "git config --global --add safe.directory '*'"
-  }
+  "postCreateCommand": "git config --global --add safe.directory '*'"
+}

--- a/.devcontainer/zshrc
+++ b/.devcontainer/zshrc
@@ -1,6 +1,9 @@
 # If you come from bash you might have to change your $PATH.
 export PATH=$HOME/bin:/usr/local/bin:$HOME/.local/bin:$PATH
 
+# Set the default shell to zsh when running zsh
+export SHELL="$(which zsh)"
+
 # Path to your oh-my-zsh installation.
 export ZSH=$HOME/.oh-my-zsh
 
@@ -49,8 +52,7 @@ bindkey "^[[1;5D" backward-word
 # Settings for the prompt to show that we are in a docker container
 export PROMPT="%K{black} 🐋 %K{blue}%F{black}%/ %f%k%F{blue}%f "  # Prefix the prompt with DOCKER
 
-# Do ros2 specific things
-source /opt/ros/iron/setup.zsh &> /dev/null
+# >>> bit-bots initialize >>>
 
 # Ignore some deprecation warnings
 export PYTHONWARNINGS=ignore:::setuptools.command.install,ignore:::setuptools.command.easy_install,ignore:::pkg_resources
@@ -72,38 +74,12 @@ export RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity}] [{name}]: {message}"
 # Set the default Middleware
 export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
-# Create a function to update the argcomplete so tab completion works
-# This needs to be called every time we source something ROS 2 related
-function update_ros2_argcomplete() {
-  eval "$(register-python-argcomplete3 colcon)"
-  eval "$(register-python-argcomplete3 ros2)"
-}
+# Load our ros plugin script containing useful functions and aliases for ROS 2 development
+if [[ -f $COLCON_WS/src/bitbots_main/scripts/ros.plugin.sh ]]; then
+  source $COLCON_WS/src/bitbots_main/scripts/ros.plugin.sh
+fi
 
-# Update the tab completion
-update_ros2_argcomplete
-
-alias rr='ros2 run'
-alias rl='ros2 launch'
-
-alias rte='ros2 topic echo'
-alias rtl='ros2 topic list'
-alias rth='ros2 topic hz'
-alias rtp='ros2 topic pub'
-
-alias rpl='ros2 param list'
-alias rpg='ros2 param get'
-
-alias cdc='cd $COLCON_WS'
-
-alias cba='cdc && colcon build --symlink-install --continue-on-error'
-alias cb='cdc && colcon build --symlink-install --continue-on-error --packages-up-to'
-alias cbs='cdc && colcon build --symlink-install --packages-select'
-alias cc='cdc && colcon clean packages --packages-select'
-alias cca='cdc && colcon clean packages'
-
-alias sr='source /opt/ros/iron/setup.zsh && update_ros2_argcomplete'
-alias sc='source $COLCON_WS/install/setup.zsh && update_ros2_argcomplete'
-alias sa='sr && sc'
+# <<< bit-bots initialize <<<
 
 # Set default editor
 export VISUAL="vim"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY : basler install install-no-root pip pre-commit install-git-filters format pull-all pull-init pull-repos pull-files fresh-libs remove-libs setup-libs rosdep status update update-no-root
+.PHONY : basler webots install install-no-root pip pre-commit install-git-filters format pull-all pull-init pull-repos pull-files fresh-libs remove-libs setup-libs rosdep status update update-no-root
 
 HTTPS := ""
 REPO:=$(dir $(abspath $(firstword $(MAKEFILE_LIST))))
@@ -6,6 +6,10 @@ REPO:=$(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 basler:
 	# Install Basler Pylon SDK
 	scripts/make_basler.sh $(ARGS)
+
+webots:
+	# Install Webots Simulation environment
+	scripts/make_webots.sh $(ARGS)
 
 install: pull-init basler update
 

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,8 @@ else
 endif
 
 rosdep:
+	# Initialize rosdep if not already done
+	[ -f /etc/ros/rosdep/sources.list.d/20-default.list ] || sudo rosdep init
 	# Update rosdep and install dependencies from meta directory
 	rosdep update
 	rosdep install --from-paths . --ignore-src --rosdistro iron -y

--- a/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
+++ b/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
@@ -8,42 +8,26 @@ In this tutorial, we will learn how to install ROS2 Iron Irwini on Ubuntu 22.04 
 
 As ROS works best on Ubuntu, we are using this distribution.
 Currently, ROS2 Iron runs on Ubuntu 22.04.
-If you are not already using Ubuntu 22.04, consider installing it on your system (perhaps as a dual boot), alternately you can run it in a virtual machine (not recommended, as recently we had some issues with it; https://www.virtualbox.org/) or use the ROS2 docker (https://github.com/timonegk/rosdocked)
+If you are not already using Ubuntu 22.04, consider installing it on your system (perhaps as a dual boot), alternately you can run it in a virtual machine (not recommended, as recently we had some issues with it; https://www.virtualbox.org/), a custom ROS2 docker setup (https://github.com/timonegk/rosdocked).
+
+Alternatively you can use a devcontainer :doc:`vscode-dev-container`, with a preconfigured environment and follow those instructions, as these docs do not apply to the devcontainer.
 
 **TLDR**: single command setup
 ------------------------------
 
 **Prerequirements**
-- running Ubuntu 22.04 environment
+- running Ubuntu 22.04 environment (native, VM, or custom ROS2 docker setup)
 - existing Github account and with SSH key added to your account
+- root access to your system (sudo)
 
-If you have not previously setup any of our software stack, you can use the following command to install and setup everything in one go:
+If you have not previously set up any of our software stack, you can use the following command to install and setup everything in one go:
 
 .. code-block:: bash
 
-  sudo apt install \
-    clang-format \
-    cppcheck \
-    python3-colcon-clean \
-    python3-colcon-common-extensions \
-    python3-pip \
-    python3-rosdep \
-    python3-vcstool \
-    ros-iron-desktop-full \
-    ros-iron-plotjuggler-ros \
-    ros-iron-rmw-cyclonedds-cpp \
-    ros-iron-rqt-robot-monitor \
-    ros-iron-rqt-runtime-monitor \
-  && python3 -m pip install \
-    git+https://github.com/ruffsl/colcon-clean \
-    git+https://github.com/timonegk/colcon-core.git@colors \
-    git+https://github.com/timonegk/colcon-notification.git@colors \
-    git+https://github.com/timonegk/colcon-output.git@colors \
-  && mkdir -p ~/git/bitbots \
-  && cd ~/git/bitbots \
-  && curl -fsSL https://raw.githubusercontent.com/bit-bots/bitbots_main/main/scripts/setup.sh > /tmp/setup.sh \
-  && bash /tmp/setup.sh
-
+  mkdir -p ~/git/bitbots \
+    && cd ~/git/bitbots \
+    && curl -fsSL https://raw.githubusercontent.com/bit-bots/bitbots_main/main/scripts/setup.sh > /tmp/setup.sh \
+    && bash /tmp/setup.sh
 
 Manual steps with in depth explanation
 --------------------------------------

--- a/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
+++ b/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
@@ -33,8 +33,9 @@ If you are not already using Ubuntu 22.04, consider installing it on your system
 
 **2. Install Webots**
 
-- Navigate to https://github.com/cyberbotics/webots/releases and download the ``.deb`` file of **Webots2022b**.
-- Install it using the command ``sudo apt install ~/Downloads/webots_2022b_amd64.deb`` or similar, depending on your system setup.
+Webots is a robot simulator, which we use to simulate our robots and test our software.
+It is not strictly necessary to install it, but it is very useful for development and testing.
+If you want to install it, you can do so by running ``make webots`` in the bitbots_main repository.
 
 **3. Download our software**
 

--- a/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
+++ b/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
@@ -3,11 +3,44 @@ Software installation with ROS2
 
 In this tutorial, we will learn how to install ROS2 Iron Irwini on Ubuntu 22.04 and build our software stack.
 
+
 **0. Use Ubuntu 22.04**
 
 As ROS works best on Ubuntu, we are using this distribution.
 Currently, ROS2 Iron runs on Ubuntu 22.04.
 If you are not already using Ubuntu 22.04, consider installing it on your system (perhaps as a dual boot), alternately you can run it in a virtual machine (not recommended, as recently we had some issues with it; https://www.virtualbox.org/) or use the ROS2 docker (https://github.com/timonegk/rosdocked)
+
+**TLDR**: single command setup
+------------------------------
+
+**Prerequirements**
+- running Ubuntu 22.04 environment
+- existing Github account and with SSH key added to your account
+
+If you have not previously setup any of our software stack, you can use the following command to install and setup everything in one go:
+
+.. code-block:: bash
+
+  sudo apt install \
+    clang-format \
+    cppcheck \
+    python3-colcon-clean \
+    python3-colcon-common-extensions \
+    python3-pip \
+    python3-rosdep \
+    python3-vcstool \
+    ros-iron-plotjuggler-ros \
+    ros-iron-rmw-cyclonedds-cpp \
+    ros-iron-rqt-robot-monitor \
+    ros-iron-rqt-runtime-monitor \
+  && mkdir -p ~/git/bitbots \
+  && cd ~/git/bitbots \
+  && curl -fsSL https://raw.githubusercontent.com/bit-bots/bitbots_main/main/scripts/setup.sh > /tmp/setup.sh \
+  && bash /tmp/setup.sh
+
+
+Manual steps with in depth explanation
+--------------------------------------
 
 **1. Setup and Install ROS 2**
 
@@ -17,17 +50,17 @@ If you are not already using Ubuntu 22.04, consider installing it on your system
 .. code-block:: bash
 
   sudo apt install \
-  clang-format \
-  cppcheck \
-  python3-colcon-clean \
-  python3-colcon-common-extensions \
-  python3-pip \
-  python3-rosdep \
-  python3-vcstool \
-  ros-iron-plotjuggler-ros \
-  ros-iron-rmw-cyclonedds-cpp \
-  ros-iron-rqt-robot-monitor \
-  ros-iron-rqt-runtime-monitor
+    clang-format \
+    cppcheck \
+    python3-colcon-clean \
+    python3-colcon-common-extensions \
+    python3-pip \
+    python3-rosdep \
+    python3-vcstool \
+    ros-iron-plotjuggler-ros \
+    ros-iron-rmw-cyclonedds-cpp \
+    ros-iron-rqt-robot-monitor \
+    ros-iron-rqt-runtime-monitor
 
 - Run ``sudo rosdep init`` to initialize ``rosdep``, a tool that helps you install system dependencies for ROS packages.
 
@@ -75,44 +108,34 @@ In case you are not using the bash shell, replace ``~/.bashrc`` and ``bash`` wit
 .. code-block:: bash
 
   cat >> ~/.bashrc << EOF
-  export PATH=\$PATH:\$HOME/.local/bin
+
+  # Ignore some deprecation warnings
+  export PYTHONWARNINGS=ignore:::setuptools.command.install,ignore:::setuptools.command.easy_install,ignore:::pkg_resources
+
+  # Limit ROS 2 communication to localhost (can be overridden when needed)
+  export ROS_DOMAIN_ID=24
+  export ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST
+
+  # Set the default colcon workspace
   export COLCON_WS="\$HOME/colcon_ws"
+
+  # Set the default log level for colcon
   export COLCON_LOG_LEVEL=30
+
+  # Define a log layout
   export RCUTILS_COLORIZED_OUTPUT=1
-  export RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity}] [{name}]: {message} ({function_name}() at {file_name}:{line_number})"
+  export RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity}] [{name}]: {message}"
+
+  # Set the default Middleware
   export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-  source /opt/ros/iron/setup.bash
-  eval "\$(register-python-argcomplete3 ros2)"
-  eval "\$(register-python-argcomplete3 colcon)"
-  EOF
 
-- Optionally, run the following command to set some useful shortcuts for various ROS2 commands:
+  # Load our ros plugin script containing useful functions and aliases for ROS 2 development
+  if [[ -f \$COLCON_WS/src/bitbots_main/scripts/ros.plugin.sh ]]; then
+    source \$COLCON_WS/src/bitbots_main/scripts/ros.plugin.sh
+  fi
 
-.. code-block:: bash
+  # <<< bit-bots initialize <<<
 
-  cat >> ~/.bashrc << EOF
-  alias rr='ros2 run'
-  alias rl='ros2 launch'
-
-  alias rte='ros2 topic echo'
-  alias rtl='ros2 topic list'
-  alias rth='ros2 topic hz'
-  alias rtp='ros2 topic pub'
-
-  alias rpl='ros2 param list'
-  alias rpg='ros2 param get'
-
-  alias cdc='cd \$COLCON_WS'
-
-  alias cba='cdc && colcon build --symlink-install --continue-on-error'
-  alias cb='cdc && colcon build --symlink-install --continue-on-error --packages-up-to'
-  alias cbs='cdc && colcon build --symlink-install --packages-select'
-  alias cc='cdc && colcon clean packages --packages-select'
-  alias cca='cdc && colcon clean packages'
-
-  alias sr='source /opt/ros/iron/setup.bash'
-  alias sc='source \$COLCON_WS/install/setup.bash'
-  alias sa='sr && sc'
   EOF
 
 - Configure the robot hostnames, see :doc:`configure_hostnames`.

--- a/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
+++ b/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
@@ -3,22 +3,13 @@ Software installation with ROS2
 
 In this tutorial, we will learn how to install ROS2 Iron Irwini on Ubuntu 22.04 and build our software stack.
 
-
-**0. Use Ubuntu 22.04**
-
-As ROS works best on Ubuntu, we are using this distribution.
-Currently, ROS2 Iron runs on Ubuntu 22.04.
-If you are not already using Ubuntu 22.04, consider installing it on your system (perhaps as a dual boot), alternately you can run it in a virtual machine (not recommended, as recently we had some issues with it; https://www.virtualbox.org/), a custom ROS2 docker setup (https://github.com/timonegk/rosdocked).
-
-Alternatively you can use a devcontainer :doc:`vscode-dev-container`, with a preconfigured environment and follow those instructions, as these docs do not apply to the devcontainer.
-
 **TLDR**: single command setup
 ------------------------------
 
 **Prerequirements**
-- running Ubuntu 22.04 environment (native, VM, or custom ROS2 docker setup)
-- existing Github account and with SSH key added to your account
-- root access to your system (sudo)
+- You have a running Ubuntu 22.04 environment
+- You have an existing Github account and added a SSH key to your account
+- You have root access to your system (sudo)
 
 If you have not previously set up any of our software stack, you can use the following command to install and setup everything in one go:
 
@@ -31,6 +22,14 @@ If you have not previously set up any of our software stack, you can use the fol
 
 Manual steps with in depth explanation
 --------------------------------------
+
+**0. Use Ubuntu 22.04**
+
+As ROS works best on Ubuntu, we are using this distribution.
+Currently, ROS2 Iron runs on Ubuntu 22.04.
+
+If you are not already using Ubuntu 22.04, consider installing it on your system (perhaps as a dual boot?).
+Alternatively you can use a devcontainer :doc:`vscode-dev-container`, with a preconfigured environment and follow those instructions, as these docs do not apply to the devcontainer.
 
 **1. Setup and Install ROS 2**
 
@@ -53,7 +52,7 @@ Manual steps with in depth explanation
     ros-iron-rqt-runtime-monitor
 
 - Run ``sudo rosdep init`` to initialize ``rosdep``, a tool that helps you install system dependencies for ROS packages.
-- To aditionally get nice colored output from colcon, you can install the following pip packages:
+- Optionally, to get nice colored output from colcon, you can install the following pip packages:
 
 .. code-block:: bash
 
@@ -71,8 +70,7 @@ If you want to install it, you can do so by running ``make webots`` in the bitbo
 
 **3. Download our software**
 
-- Create a GitHub account, if not already done (see here for further information on this: http://doku.bit-bots.de/private/manual/dienste_accounts.html)
-  Those services host our Git software repositories.
+- Create a GitHub account, if not already done (see `here <http://doku.bit-bots.de/private/manual/dienste_accounts.html>` for further information)
 - Add your SSH key to GitHub to access and sync our repositories
     - If you don't know what I am talking about or you don't yet have a SSH key, follow this guide: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/checking-for-existing-ssh-keys
     - Go to your account settings and add your SSH key (the ``.pub`` file) to `GitHub <https://github.com/settings/keys>`_
@@ -108,6 +106,8 @@ In case you are not using the bash shell, replace ``~/.bashrc`` and ``bash`` wit
 
   cat >> ~/.bashrc << EOF
 
+  # >>> bit-bots initialize >>>
+
   # Ignore some deprecation warnings
   export PYTHONWARNINGS=ignore:::setuptools.command.install,ignore:::setuptools.command.easy_install,ignore:::pkg_resources
 
@@ -139,6 +139,12 @@ In case you are not using the bash shell, replace ``~/.bashrc`` and ``bash`` wit
 
 - Configure the robot hostnames, see :doc:`configure_hostnames`.
 
-**6. Troubleshooting**
+Notes
+-----
 
-If you have some problems with your installation, like not finding any nodes or topics, referr here for some troubleshooting steps: https://docs.ros.org/en/rolling/How-To-Guides/Installation-Troubleshooting.html
+Custom docker setup
+  Before utilizing a devcontainer, we used a custom docker setup for ROS 2 development.
+  If you want (or need) to utilize a custom setup like this, have a look at https://github.com/timonegk/rosdocked.
+
+Virtual Machine setup
+  We recommend against using a virtual machine for ROS 2 development, both for compile speed and setup complexity reasons.

--- a/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
+++ b/bitbots_misc/bitbots_docs/docs/manual/tutorials/install_software_ros2.rst
@@ -29,10 +29,16 @@ If you have not previously setup any of our software stack, you can use the foll
     python3-pip \
     python3-rosdep \
     python3-vcstool \
+    ros-iron-desktop-full \
     ros-iron-plotjuggler-ros \
     ros-iron-rmw-cyclonedds-cpp \
     ros-iron-rqt-robot-monitor \
     ros-iron-rqt-runtime-monitor \
+  && python3 -m pip install \
+    git+https://github.com/ruffsl/colcon-clean \
+    git+https://github.com/timonegk/colcon-core.git@colors \
+    git+https://github.com/timonegk/colcon-notification.git@colors \
+    git+https://github.com/timonegk/colcon-output.git@colors \
   && mkdir -p ~/git/bitbots \
   && cd ~/git/bitbots \
   && curl -fsSL https://raw.githubusercontent.com/bit-bots/bitbots_main/main/scripts/setup.sh > /tmp/setup.sh \
@@ -63,6 +69,15 @@ Manual steps with in depth explanation
     ros-iron-rqt-runtime-monitor
 
 - Run ``sudo rosdep init`` to initialize ``rosdep``, a tool that helps you install system dependencies for ROS packages.
+- To aditionally get nice colored output from colcon, you can install the following pip packages:
+
+.. code-block:: bash
+
+  python3 -m pip install \
+    git+https://github.com/ruffsl/colcon-clean \
+    git+https://github.com/timonegk/colcon-core.git@colors \
+    git+https://github.com/timonegk/colcon-notification.git@colors \
+    git+https://github.com/timonegk/colcon-output.git@colors
 
 **2. Install Webots**
 

--- a/scripts/make_basler.sh
+++ b/scripts/make_basler.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eEo pipefail
 
 # You need to fill out a form to download the pylon driver.
 # The pylon driver can be found in the download section of the following link:
@@ -25,10 +26,9 @@ else
     SHOW_PROGRESS="--show-progress"
 fi
 
-# Create function to check if we have an internet connection
-function check_internet_connection () {
+check_internet_connection () {
     # Check if we have an internet connection, except in the ci as azure does not support ping by design
-    if [[ $1 != "--ci" ]] && ! ping -q -c 1 -W 1 google.com >/dev/null; then
+    if [[ $1 != "--ci" ]] && ! ping -q -c 1 -W 1 google.com > /dev/null; then
         echo "No internet connection. Please check your internet connection to install the basler drivers."
         exit 1
     fi
@@ -40,7 +40,7 @@ if apt list pylon --installed | grep -q $PYLON_VERSION; then
 else
     echo "Pylon driver $PYLON_VERSION is not installed. Installing..."
     # Check if we have an internet connection
-    check_internet_connection $1
+    check_internet_connection "$1"
     # Check if the url exist
     if ! curl --output /dev/null --silent --head --fail "$PYLON_DOWNLOAD_URL"; then
         echo "Pylon download url does not exist. Please check the url and update the 'PYLON_DOWNLOAD_URL' variable in the 'make_basler.sh' script. The website might have changed."

--- a/scripts/make_webots.sh
+++ b/scripts/make_webots.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eEo pipefail
+
+WEBOTS_VERSION="2022b"
+WEBOTS_DOWNLOAD_URL="https://github.com/cyberbotics/webots/releases/download/R${WEBOTS_VERSION}/webots_${WEBOTS_VERSION}_amd64.deb"
+
+check_internet_connection () {
+    if ! ping -q -c 1 -W 1 google.com > /dev/null; then
+        echo "No internet connection. Please check your internet connection to install the webots simulator."
+        exit 1
+    fi
+}
+
+# Check if the correct webots simulator WEBOTS_VERSION is installed (apt)
+if apt list webots --installed | grep -q "$WEBOTS_VERSION"; then
+    echo "Webots simulator release $WEBOTS_VERSION is already installed."
+else
+    echo "Webots simulator release $WEBOTS_VERSION is not installed. Installing..."
+    # Check if we have an internet connection
+    check_internet_connection
+    # Check if the url exist
+    if ! curl --output /dev/null --silent --head --fail "$WEBOTS_DOWNLOAD_URL"; then
+        echo "Webots download url does not exist. Please check the url and update the 'WEBOTS_DOWNLOAD_URL' variable in the 'make_webots.sh' script."
+        exit 1
+    fi
+    # Download the webots simulator dep package to temp folder
+    wget --no-verbose --show-progress "$WEBOTS_DOWNLOAD_URL" -O "/tmp/webots_${WEBOTS_VERSION}.deb"
+    # Install the webots simulator
+    sudo apt-get install "/tmp/webots_${WEBOTS_VERSION}.deb" -y
+fi

--- a/scripts/ros.plugin.sh
+++ b/scripts/ros.plugin.sh
@@ -1,4 +1,4 @@
-### Aliases and functions for ros2/colcon usage. Usage for either
+### Aliases and functions for ROS 2 and colcon usage. Usage for either
 ### Ubuntu 22.04 or in rosdocked/dev docker container
 
 shell="$(basename "$SHELL")"
@@ -8,9 +8,9 @@ rid() {
   echo "ROS_DOMAIN_ID set to $ROS_DOMAIN_ID"
 }
 
-# Create a function to update the argcomplete so tab completion works
-# This needs to be called every time we source something ROS 2 related
-# For this previous loading of bashcompinit is required
+# Create a function to update the argcomplete so tab completion works.
+# This needs to be called every time we source something ROS 2 related.
+# Previous loading of bashcompinit is required.
 update_ros2_argcomplete() {
   eval "$(register-python-argcomplete3 colcon)"
   eval "$(register-python-argcomplete3 ros2)"

--- a/scripts/ros.plugin.sh
+++ b/scripts/ros.plugin.sh
@@ -1,0 +1,50 @@
+### Aliases and functions for ros2/colcon usage. Usage for either
+### Ubuntu 22.04 or in rosdocked/dev docker container
+
+shell="$(basename "$SHELL")"
+
+rid() {
+  export ROS_DOMAIN_ID="$1"
+  echo "ROS_DOMAIN_ID set to $ROS_DOMAIN_ID"
+}
+
+# Create a function to update the argcomplete so tab completion works
+# This needs to be called every time we source something ROS 2 related
+# For this previous loading of bashcompinit is required
+update_ros2_argcomplete() {
+  eval "$(register-python-argcomplete3 colcon)"
+  eval "$(register-python-argcomplete3 ros2)"
+}
+
+# Source the ROS 2 setup files if iron is installed
+if [[ -d /opt/ros/iron ]]; then
+  source "/opt/ros/iron/setup.$shell" &> /dev/null
+fi
+
+# Update the tab completion
+update_ros2_argcomplete
+
+# ros aliases
+alias rr='ros2 run'
+alias rl='ros2 launch'
+
+alias rte='ros2 topic echo'
+alias rtl='ros2 topic list'
+alias rth='ros2 topic hz'
+alias rtp='ros2 topic pub'
+
+alias rpl='ros2 param list'
+alias rpg='ros2 param get'
+
+# colcon aliases
+alias cdc='cd $COLCON_WS'
+
+alias cba='cdc && colcon build --symlink-install --continue-on-error'
+alias cbs='cdc && colcon build --symlink-install --packages-select'
+alias cb='cdc && colcon build --symlink-install --continue-on-error --packages-up-to'
+alias cc='cdc && colcon clean packages --packages-select'
+alias cca='cdc && colcon clean packages'
+
+alias sr="source /opt/ros/iron/setup.$shell && update_ros2_argcomplete"
+alias sc="source \$COLCON_WS/install/setup.$shell && update_ros2_argcomplete"
+alias sa='sr && sc'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -52,6 +52,35 @@ ask_question() {
     done
 }
 
+setup_ros() {
+    if (( has_sudo )); then
+        echo "Setting up ROS 2..."
+
+        if [[ ! -f /etc/apt/sources.list.d/ros2.list ]]; then
+            echo "Adding ROS 2 repository..."
+            sudo apt install -y curl lsb-release
+            curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key > /usr/share/keyrings/ros-archive-keyring.gpg
+            sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main' > /etc/apt/sources.list.d/ros2.list"
+        fi
+
+        sudo apt update && sudo apt install -y \
+            clang-format \
+            cppcheck \
+            python3-colcon-clean \
+            python3-colcon-common-extensions \
+            python3-pip \
+            python3-rosdep \
+            python3-vcstool \
+            "ros-${ROS_DISTRO}-desktop-full" \
+            "ros-${ROS_DISTRO}-plotjuggler-ros" \
+            "ros-${ROS_DISTRO}-rmw-cyclonedds-cpp" \
+            "ros-${ROS_DISTRO}-rqt-robot-monitor" \
+            "ros-${ROS_DISTRO}-rqt-runtime-monitor"
+    else
+        echo "Please install ROS 2 manually!"
+    fi
+}
+
 setup_repo() {
     echo "Setting up bitbots_main repository..."
 
@@ -75,7 +104,15 @@ setup_repo() {
     fi
 }
 
-setup_colcon_workspace() {
+setup_colcon() {
+    echo "Installing/Updating colcon extensions..."
+
+    # Install/Update colcon extensions / patches
+    python3 -m pip install --upgrade --user \
+      git+https://github.com/timonegk/colcon-core.git@colors \
+      git+https://github.com/timonegk/colcon-notification.git@colors \
+      git+https://github.com/timonegk/colcon-output.git@colors
+
     if [[ ! -d "$COLCON_WS/src/bitbots_main" ]]; then
         echo "Setting up colcon workspace in $COLCON_WS..."
         mkdir -p "$COLCON_WS/src"
@@ -126,7 +163,8 @@ if [[ ! -d "$meta_dir/.git" ]]; then
     in_repo=0
 fi
 
+setup_ros
 setup_repo
-setup_colcon_workspace
+setup_colcon
 setup_shell_aliases
 build_repository

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -131,7 +131,7 @@ build_repository() {
 }
 
 setup_shell_aliases() {
-    if ask_question "Do you want to setup/update the bit-bots ros2/colcon shell configuration?"; then
+    if ask_question "Do you want to setup/update the Bit-Bots ROS 2 and colcon shell configuration?"; then
         local shell_config_file
 
         if [[ "$SHELL" =~ "bash" ]]; then
@@ -154,7 +154,7 @@ if ask_question "Do you have sudo rights?"; then
     has_sudo=1
 fi
 if (( ! has_sudo )); then
-    echo "Because, you don't have sudo rights, you need ensure all necessary ros packages are preinstalled."
+    echo "Because, you don't have sudo rights, ensure all necessary ROS 2 packages are installed."
 fi
 
 in_repo=1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -eEuo pipefail
+
+# static/global variables
+ROS_DISTRO=${ROS_DISTRO:-"iron"}
+DIR="$(dirname "$(readlink -f "$0")")"
+COLCON_WS="${COLCON_WS:-"$HOME/colcon_ws"}"
+REPO_URL="git@github.com:bit-bots/bitbots_main.git"
+SHELL_CONFIG="$(cat <<EOF
+
+# >>> bit-bots initialize >>>
+
+# Ignore some deprecation warnings
+export PYTHONWARNINGS=ignore:::setuptools.command.install,ignore:::setuptools.command.easy_install,ignore:::pkg_resources
+
+# Limit ROS 2 communication to localhost (can be overridden when needed)
+export ROS_DOMAIN_ID=24
+export ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST
+
+# Set the default colcon workspace
+export COLCON_WS="\$HOME/colcon_ws"
+
+# Set the default log level for colcon
+export COLCON_LOG_LEVEL=30
+
+# Define a log layout
+export RCUTILS_COLORIZED_OUTPUT=1
+export RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity}] [{name}]: {message}"
+
+# Set the default Middleware
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+
+# Load our ros plugin script containing useful functions and aliases for ROS 2 development
+if [[ -f \$COLCON_WS/src/bitbots_main/scripts/ros.plugin.sh ]]; then
+  source \$COLCON_WS/src/bitbots_main/scripts/ros.plugin.sh
+fi
+
+# <<< bit-bots initialize <<<
+
+EOF
+)"
+
+ask_question() {
+    while true; do
+        read -p "$1 [Y/n]: " -n 1 -r response
+        echo ""
+        case $response in
+            [Yy] | "") return 0;;
+            [Nn]) return 1;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
+}
+
+setup_repo() {
+    echo "Setting up bitbots_main repository..."
+
+    if (( in_repo )); then
+        cd "$meta_dir" || exit
+    else
+        if [[ ! -d "$PWD/bitbots_main" ]]; then
+            git clone "$REPO_URL"
+        fi
+
+        meta_dir="$(realpath "$PWD/bitbots_main")"
+        cd "$meta_dir" || exit
+    fi
+
+    echo "Installing dependencies..."
+    if (( has_sudo )); then
+        make install
+    else
+        echo "Cannot use rosdep as it requires sudo."
+        make install-no-root
+    fi
+}
+
+setup_colcon_workspace() {
+    if [[ ! -d "$COLCON_WS/src/bitbots_main" ]]; then
+        echo "Setting up colcon workspace in $COLCON_WS..."
+        mkdir -p "$COLCON_WS/src"
+        ln -s "$meta_dir" "$COLCON_WS/src/bitbots_main"
+    fi
+}
+
+build_repository() {
+    echo "Running full colcon build for bitbots_main repository..."
+    cd "$COLCON_WS"
+
+    set +u
+    source "/opt/ros/${ROS_DISTRO}/setup.bash"
+
+    colcon build --symlink-install --continue-on-error
+}
+
+setup_shell_aliases() {
+    if ask_question "Do you want to setup/update the bit-bots ros2/colcon shell configuration?"; then
+        local shell_config_file
+
+        if [[ "$SHELL" =~ "bash" ]]; then
+            shell_config_file="$HOME/.bashrc"
+        elif [[ "$SHELL" =~ "zsh" ]]; then
+            shell_config_file="$HOME/.zshrc"
+        else
+            echo "Your shell is not supported!"
+            exit 1
+        fi
+
+        if ! grep -q ">>> bit-bots initialize >>>" "$shell_config_file"; then
+            echo "$SHELL_CONFIG" >> "$shell_config_file"
+        fi
+    fi
+}
+
+has_sudo=0
+if ask_question "Do you have sudo rights?"; then
+    has_sudo=1
+fi
+if (( ! has_sudo )); then
+    echo "Because, you don't have sudo rights, you need ensure all necessary ros packages are preinstalled."
+fi
+
+in_repo=1
+meta_dir="$(realpath "$DIR/../")"
+if [[ ! -d "$meta_dir/.git" ]]; then
+    in_repo=0
+fi
+
+setup_repo
+setup_colcon_workspace
+setup_shell_aliases
+build_repository


### PR DESCRIPTION
# Summary
Write setup script, which allows for full setup of repository and environment for development including:
- cloning of the repo
- setup of `rosdep init`
- setup of zsh configuration and inclusion of ros/colcon aliases/functions
- setup with `make install` or without sudo `make install-no-root`
- optional install of webots
- full colcon build of all packages

## Proposed changes
For easier management of ros/colcon aliases and utility functions I have created a `ros.plugin.sh` file, which can be sourced in either `.bashrc` or `.zshrc` and have also adjusted the devcontainer to use it.

Additionally, while testing permission issues with devcontainer became apparent #357. 

## Checklist

- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
