### PR TITLE
Fix vision qos policy

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -57,12 +57,9 @@ RUN apt-get install -y \
   ros-iron-camera-calibration \
   ros-iron-desktop \
   ros-iron-joint-state-publisher-gui \
-  # ros-iron-plotjuggler-ros containing plotjuggler ros plugins
-  # build currently fails and is not available as a package so we
-  # have to manually install plotjuggler and plotjuggler-msgs
-  # https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/59
   ros-iron-plotjuggler \
   ros-iron-plotjuggler-msgs \
+  ros-iron-plotjuggler-ros \
   ros-iron-rmw-cyclonedds-cpp \
   ros-iron-rqt-robot-monitor \
   ros-iron-soccer-vision-3d-rviz-markers

--- a/bitbots_vision/bitbots_vision/vision.py
+++ b/bitbots_vision/bitbots_vision/vision.py
@@ -8,6 +8,7 @@ from ament_index_python.packages import get_package_share_directory
 from cv_bridge import CvBridge
 from rcl_interfaces.msg import SetParametersResult
 from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
 from sensor_msgs.msg import Image
 
 from bitbots_vision.vision_modules import ros_utils, yoeo
@@ -125,7 +126,14 @@ class YOEOVision(Node):
 
     def _register_subscribers(self, config: Dict) -> None:
         self._sub_image = ros_utils.create_or_update_subscriber(
-            self, self._config, config, self._sub_image, "ROS_img_msg_topic", Image, callback=self._image_callback
+            self,
+            self._config,
+            config,
+            self._sub_image,
+            "ROS_img_msg_topic",
+            Image,
+            callback=self._image_callback,
+            qos_profile=qos_profile_sensor_data,
         )
 
     def _image_callback(self, image_msg: Image) -> None:


### PR DESCRIPTION
# Summary
- Somehow the qos policy of the image proc publisher changed. This adapts the vision qos policy to reflect that.
- Also add plotjuggler back to dev container

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
