### PR TITLE
Use the ruff vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,27 +1,28 @@
 {
     "recommendations": [
-        "cschlosser.doxdocgen",  // Generates doxygen comments
-        "DavidAnson.vscode-markdownlint",  // Lints markdown files
-        "DotJoshJohnson.xml",  // XML support
-        "eamodio.gitlens",  // Extended git highlighting
-        "lextudio.restructuredtext",  // Rendering rst files in preview
-        "mohsen1.prettify-json",  // JSON formatting
-        "ms-azuretools.vscode-docker",  // Docker support
-        "MS-CEINTL.vscode-language-pack-de",  // German language pack
-        "ms-iot.vscode-ros",  // ROS support
-        "ms-python.python",  // Python support
-        "ms-python.vscode-pylance",  // Python support
-        "ms-vscode.cmake-tools",  // CMake support
-        "ms-vscode.cpptools-extension-pack",  // C++ support
-        "ms-vscode.cpptools-themes",  // C++ support
-        "ms-vscode.cpptools",  // C++ support
-        "njpwerner.autodocstring",  // Generates docstrings
-        "streetsidesoftware.code-spell-checker-german",  // Spell checker
-        "streetsidesoftware.code-spell-checker",  // Spell checker
-        "tamasfe.even-better-toml",  // TOML support
-        "trond-snekvik.simple-rst",  // Syntax highlighting for rst files
-        "twxs.cmake",  // CMake support
-        "zxh404.vscode-proto3",  // Protobuf support
+        "charliermarsh.ruff", // Ruff linting and formatting support
+        "cschlosser.doxdocgen", // Generates doxygen comments
+        "DavidAnson.vscode-markdownlint", // Lints markdown files
+        "DotJoshJohnson.xml", // XML support
+        "eamodio.gitlens", // Extended git highlighting
+        "lextudio.restructuredtext", // Rendering rst files in preview
         "Mastermori.dsd", // DSD support
+        "mohsen1.prettify-json", // JSON formatting
+        "ms-azuretools.vscode-docker", // Docker support
+        "MS-CEINTL.vscode-language-pack-de", // German language pack
+        "ms-iot.vscode-ros", // ROS support
+        "ms-python.python", // Python support
+        "ms-python.vscode-pylance", // Python support
+        "ms-vscode.cmake-tools", // CMake support
+        "ms-vscode.cpptools-extension-pack", // C++ support
+        "ms-vscode.cpptools-themes", // C++ support
+        "ms-vscode.cpptools", // C++ support
+        "njpwerner.autodocstring", // Generates docstrings
+        "streetsidesoftware.code-spell-checker-german", // Spell checker
+        "streetsidesoftware.code-spell-checker", // Spell checker
+        "tamasfe.even-better-toml", // TOML support
+        "trond-snekvik.simple-rst", // Syntax highlighting for rst files
+        "twxs.cmake", // CMake support
+        "zxh404.vscode-proto3", // Protobuf support
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -192,7 +192,6 @@
         "valarray": "cpp",
         "variant": "cpp"
     },
-
     // Tell the ROS extension where to find the setup.bash
     // This also utilizes the COLCON_WS environment variable, which needs to be set
     "ros.distro": "iron",
@@ -204,4 +203,6 @@
         "/opt/ros/iron/lib/python3.10/site-packages"
     ],
     "cmake.configureOnOpen": false,
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "charliermarsh.ruff",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,15 @@
-[tool.black]
-line-length = 120
-
 [tool.ruff]
 line-length = 120
- # Never enforce `E501` (line length violations), as black takes care of this.
+
+[tool.ruff.lint]
+# Never enforce `E501` (line length violations)
 ignore = ["E501", "UP007"]
 # Additionally enable the following rules
 # - pycodestyle warnings (`W`)
 # - flake8-bugbear warnings (`B`)
-# - isort import sorting (`I`)
+# - isort import sorting (`I001`)
 # - pep8-naming convenrtions (`N`)
 # - pyupgrade prefer newer language constructs (`UP`)
-select = ["F", "E", "B", "W", "I", "N", "UP"]
+select = ["F", "E", "B", "W", "I001", "N", "UP"]
 # Do not lint the following directories
 exclude = ["lib"]


### PR DESCRIPTION
# Summary
Better configuration for ruff

## Proposed changes
- Include the ruff vscode extension
- Setting to automatically format on save
- Remove old black config and cleanup of pyproject.toml

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [X] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [X] Triage this PR and label it
