### PR TITLE
Add infos regarding git crypt to docs

### DIFF
--- a/bitbots_misc/bitbots_docs/docs/manual/tutorials/competition_wifi.rst
+++ b/bitbots_misc/bitbots_docs/docs/manual/tutorials/competition_wifi.rst
@@ -7,10 +7,10 @@ This is done by editing the `group_vars/robots.yml <https://git.mafiasi.de/Bit-B
 
 .. code-block:: yaml
 
-   # To configure competition wifi uncomment the lines below 
+   # To configure competition wifi uncomment the lines below
    # configure team_number,  connection_name (SSID), connection_password, ip/gateway
-   # and run ansible-playbook ./playbooks/setup_robots.yml --tags competition_wifi.
-   
+   # and run ansible-playbook ./playbooks/setup_robots.yml --tags competition_wifi --skip-tags git_crypt.
+
    team_number: 6
    network_configure_competition_wifi: true
    network_competition_wifi_connections:
@@ -23,4 +23,4 @@ This is done by editing the `group_vars/robots.yml <https://git.mafiasi.de/Bit-B
        ip: "192.168.0.{{ team_number }}{{ player_number }}"
        gateway: 192.168.0.1
 
-Then run ``ansible-playbook ./playbooks/setup_robots.yml --tags competition_wifi`` to apply this configuration.
+Then run ``ansible-playbook ./playbooks/setup_robots.yml --tags competition_wifi --skip-tags git_crypt`` to apply this configuration.

--- a/bitbots_misc/bitbots_docs/docs/manual/tutorials/configure_and_flash_robot.rst
+++ b/bitbots_misc/bitbots_docs/docs/manual/tutorials/configure_and_flash_robot.rst
@@ -107,6 +107,8 @@ To run the whole setup on a specific robot execute the following in the ansible 
 
   ansible-playbook ./playbooks/setup_robots.yml --ask-become-pass --limit <nuc*>
 
+if you dont have access to the secret git-crypt data you can add ``--skip-tags git_crypt`` to the command.
+
 Ansible will execute the playbook with the ``bitbots`` user on the robots and will ask for its password to be able to utilize ``sudo``.
 
 .. note::


### PR DESCRIPTION
# Summary
Currently, ansible throws an error is the commands are executed as described. The error message is not very helpful and a note with the possible fix in the docs is useful imo..
