### PR TITLE
Fix fieldname launch comment

### DIFF
--- a/bitbots_navigation/bitbots_localization/launch/localization.launch
+++ b/bitbots_navigation/bitbots_localization/launch/localization.launch
@@ -2,8 +2,8 @@
     <!-- define parameters -->
     <arg name="tf_prefix" default=""/>
     <arg name="sim" default="false" description="true: activates simulation time and might load different parameters"/>
-    <arg unless="$(var sim)" name="fieldname" default="german_open_2024" description="Loads field settings (labor, webots, gazebo, bangkok, spl, german_open)." />
-    <arg if="$(var sim)" name="fieldname" default="webots" description="Loads field settings (labor, webots, gazebo, bangkok, german_open)." />
+    <arg unless="$(var sim)" name="fieldname" default="german_open_2024" description="Loads field settings (labor, webots, gazebo, bangkok, spl, german_open_2024)." />
+    <arg if="$(var sim)" name="fieldname" default="webots" description="Loads field settings (labor, webots, gazebo, bangkok, german_open_2024)." />
 
     <let if="$(env IS_ROBOT false)" name="taskset" value="taskset -c 8"/>
     <let unless="$(env IS_ROBOT false)" name="taskset" value=""/>


### PR DESCRIPTION
# Summary
Use correct `german_open_2024` instead of `german_open` in `localization.launch` as introduced in #379 

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [X] Triage this PR and label it
