### PR TITLE
Enable teamcomm by default in teamplayer

### DIFF
--- a/bitbots_misc/bitbots_bringup/launch/teamplayer.launch
+++ b/bitbots_misc/bitbots_bringup/launch/teamplayer.launch
@@ -9,7 +9,7 @@
     <arg name="motion" default="true" description="Whether the motion control system should be started" />
     <arg name="path_planning" default="true" description="Whether the path planning should be started"/>
     <arg name="sim" default="false" description="Whether the robot is running in simulation or on real hardware" />
-    <arg name="teamcom" default="false" description="Whether the team communication system should be started" />
+    <arg name="teamcom" default="true" description="Whether the team communication system should be started" />
     <arg name="vision" default="true" description="Whether the vision system should be started" />
     <arg name="world_model" default="true" description="Whether the world model should be started"/>
     <arg name="monitoring" default="true" description="Whether the system monitor and udp bridge should be started" />


### PR DESCRIPTION
# Summary
Enable teamcomm by default in `teamplayer.launch`

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [X] Triage this PR and label it
