### PR TITLE
Consistent `game_settings.yaml` over deployment syncs

### DIFF
--- a/bitbots_misc/bitbots_utils/config/default_game_settings.yaml
+++ b/bitbots_misc/bitbots_utils/config/default_game_settings.yaml
@@ -1,7 +1,7 @@
 parameter_blackboard:
   ros__parameters:
     bot_id: 1
-    monitoring_host_ip: 0.0.0.0
+    monitoring_host_ip: 172.20.0.10
     position_number: 0
     role: offense
     team_color: 0

--- a/sync_includes_wolfgang_nuc.yaml
+++ b/sync_includes_wolfgang_nuc.yaml
@@ -70,3 +70,4 @@ exclude:
     - ".idea"
     - ".vscode"
     - "__pycache__"
+    - "bitbots_utils/config/game_settings.yaml"


### PR DESCRIPTION
# Summary
The `game_settings.yaml` were added to the excludes for syncing, and we now use a merge of a dict of defaults with the current `game_settings.yaml` from the last configuration.
This has the effect, that if the settings were already configured, they can stay the same and the user only has to accept.
Additionally at the end of the configuration process, the user is now shown the current configuration, that will be written and has to accept or can choose to redo the process with a `[Y/n]` prompt.

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
