### PR TITLE
Play init animation before walkready at startup

### DIFF
--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/play_animation.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/play_animation.py
@@ -23,7 +23,7 @@ class AbstractPlayAnimation(AbstractHCMActionElement, ABC):
         if self.first_perform:
             # get the animation that should be played
             # defined by implementations of this abstract class
-            anim = self.chose_animation()
+            anim = self.choose_animation()
 
             # try to start animation
             sucess = self.start_animation(anim)
@@ -41,7 +41,7 @@ class AbstractPlayAnimation(AbstractHCMActionElement, ABC):
             return self.pop()
 
     @abstractmethod
-    def chose_animation(self):
+    def choose_animation(self):
         # this is what has to be implemented returning the animation to play
         raise NotImplementedError
 
@@ -96,39 +96,44 @@ class AbstractPlayAnimation(AbstractHCMActionElement, ABC):
 
 
 class PlayAnimationFallingLeft(AbstractPlayAnimation):
-    def chose_animation(self):
+    def choose_animation(self):
         self.blackboard.node.get_logger().info("PLAYING FALLING LEFT ANIMATION")
         return self.blackboard.animation_name_falling_left
 
 
 class PlayAnimationFallingRight(AbstractPlayAnimation):
-    def chose_animation(self):
+    def choose_animation(self):
         self.blackboard.node.get_logger().info("PLAYING FALLING RIGHT ANIMATION")
         return self.blackboard.animation_name_falling_right
 
 
 class PlayAnimationFallingFront(AbstractPlayAnimation):
-    def chose_animation(self):
+    def choose_animation(self):
         self.blackboard.node.get_logger().info("PLAYING FALLING FRONT ANIMATION")
         return self.blackboard.animation_name_falling_front
 
 
 class PlayAnimationFallingBack(AbstractPlayAnimation):
-    def chose_animation(self):
+    def choose_animation(self):
         self.blackboard.node.get_logger().info("PLAYING FALLING BACK ANIMATION")
         return self.blackboard.animation_name_falling_back
 
 
 class PlayAnimationTurningBackLeft(AbstractPlayAnimation):
-    def chose_animation(self):
+    def choose_animation(self):
         self.blackboard.node.get_logger().info("LYING ON THE LEFT SIDE AND TURNING TO THE BACK TO GET UP")
         return self.blackboard.animation_name_turning_back_left
 
 
 class PlayAnimationTurningBackRight(AbstractPlayAnimation):
-    def chose_animation(self):
+    def choose_animation(self):
         self.blackboard.node.get_logger().info("LYING ON THE RIGHT SIDE AND TURNING TO THE BACK TO GET UP")
         return self.blackboard.animation_name_turning_back_right
+
+
+class PlayAnimationInit(AbstractPlayAnimation):
+    def choose_animation(self):
+        return self.blackboard.animation_name_init
 
 
 class PlayAnimationDynup(AbstractHCMActionElement):

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm.dsd
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm.dsd
@@ -1,6 +1,6 @@
 -->HCM
 $StartHCM
-    START_UP --> @RobotStateStartup, @PlayAnimationDynup + direction:walkready
+    START_UP --> @RobotStateStartup, @PlayAnimationInit, @PlayAnimationDynup + direction:walkready
     RUNNING --> $CheckMotors
         MOTORS_NOT_STARTED --> @RobotStateStartup, @Wait
         OVERLOAD --> @RobotStateMotorOff, @CancelGoals, @StopWalking, @PlayAnimationFallingFront, @TurnMotorsOff, @Wait

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm_blackboard.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm_blackboard.py
@@ -71,6 +71,7 @@ class HcmBlackboard:
         self.animation_name_falling_right: str = self.node.get_parameter("animations.falling_right").value
         self.animation_name_turning_back_left: str = self.node.get_parameter("animations.turning_back_left").value
         self.animation_name_turning_back_right: str = self.node.get_parameter("animations.turning_back_right").value
+        self.animation_name_init: str = self.node.get_parameter("animations.init").value
 
         # Teaching State
         self.teaching_mode_state: int = SetTeachingMode.Request.OFF

--- a/bitbots_motion/bitbots_hcm/config/hcm_wolfgang.yaml
+++ b/bitbots_motion/bitbots_hcm/config/hcm_wolfgang.yaml
@@ -19,6 +19,7 @@
       falling_right: "falling_right"
       turning_back_left: "turning_back_left"
       turning_back_right: "turning_back_right"
+      init: "init"
 
     # Falling
     stand_up_active: true # Enables the robot to stand up automatically

--- a/bitbots_wolfgang/wolfgang_animations/animations/motion/init.json
+++ b/bitbots_wolfgang/wolfgang_animations/animations/motion/init.json
@@ -21,9 +21,9 @@
                 "LHipRoll": 0.0,
                 "RHipRoll": 0.0,
                 "LAnkleRoll": 0.0,
-                "LElbow": 0,
-                "RElbow": 0,
-                "RHipPitch": 0,
+                "LElbow": 0.0,
+                "RElbow": 0.0,
+                "RHipPitch": 0.0,
                 "HeadPan": 0.0,
                 "RShoulderPitch": 0.0
             }


### PR DESCRIPTION
# Summary
Plays animation init before playing walkready at the first startup. This helps to fix problems with colliding feet.