### PR TITLE
Estimate yaw for localization reinit after fall

### DIFF
--- a/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/actions/initialize.py
+++ b/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/actions/initialize.py
@@ -80,8 +80,11 @@ class InitPoseAfterFall(AbstractInitialize):
         # Calculate the angle of the robot after the fall by adding the yaw difference during the fall
         # (estimated by the IMU) to the last known localization yaw
         esimated_angle = (
-            self.blackboard.get_imu_yaw() - self.blackboard.imu_yaw_before_fall + self.blackboard.get_localization_yaw()
-        + math.tau) % math.tau
+            self.blackboard.get_imu_yaw()
+            - self.blackboard.imu_yaw_before_fall
+            + self.blackboard.get_localization_yaw()
+            + math.tau
+        ) % math.tau
 
         # Tell the localization to reset to the last position and the estimated angle
         self.blackboard.reset_filter_proxy.call_async(

--- a/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/actions/initialize.py
+++ b/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/actions/initialize.py
@@ -80,13 +80,8 @@ class InitPoseAfterFall(AbstractInitialize):
         # Calculate the angle of the robot after the fall by adding the yaw difference during the fall
         # (estimated by the IMU) to the last known localization yaw
         esimated_angle = (
-            (
-                self.blackboard.get_imu_yaw()
-                - self.blackboard.imu_yaw_before_fall
-                + self.blackboard.get_localization_yaw()
-            )
-            % math.tau,
-        )
+            self.blackboard.get_imu_yaw() - self.blackboard.imu_yaw_before_fall + self.blackboard.get_localization_yaw()
+        ) % math.tau
 
         # Tell the localization to reset to the last position and the estimated angle
         self.blackboard.reset_filter_proxy.call_async(
@@ -153,7 +148,7 @@ class RedoLastInit(AbstractInitialize):
         return self.sub_action.perform(reevaluate)
 
 
-class StoreCurrentIMUYaw(AbstractInitialize):
+class StoreCurrentIMUYaw(AbstractLocalizationActionElement):
     def perform(self, reevaluate=False):
         self.do_not_reevaluate()
         self.blackboard.node.get_logger().debug("Storing current IMU yaw")

--- a/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/actions/initialize.py
+++ b/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/actions/initialize.py
@@ -81,7 +81,7 @@ class InitPoseAfterFall(AbstractInitialize):
         # (estimated by the IMU) to the last known localization yaw
         esimated_angle = (
             self.blackboard.get_imu_yaw() - self.blackboard.imu_yaw_before_fall + self.blackboard.get_localization_yaw()
-        ) % math.tau
+        + math.tau) % math.tau
 
         # Tell the localization to reset to the last position and the estimated angle
         self.blackboard.reset_filter_proxy.call_async(

--- a/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/localization.dsd
+++ b/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/localization.dsd
@@ -9,9 +9,9 @@ $SecondaryStateDecider
 
 -->Localization
 $GettingUpState
-    YES --> @LocalizationStop, @DoNothing
+    YES --> @StoreCurrentIMUYaw, @LocalizationStop, @DoNothing
     GOTUP --> $WalkedSinceLastInit + dist:%walking_moved_distance
-        YES --> @InitPosition, @LocalizationStart, @DoNothing
+        YES --> @InitPoseAfterFall, @LocalizationStart, @DoNothing
         NO --> @RedoLastInit, @LocalizationStart, @DoNothing
     NO --> $CheckGameStateReceived
         NO_GAMESTATE_INIT --> @InitSide, @DoNothing

--- a/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/localization_blackboard.py
+++ b/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/localization_blackboard.py
@@ -52,7 +52,7 @@ class LocalizationBlackboard:
         self.last_state_get_up = False
 
         # IMU
-        self.accel = np.array([0, 0, 0])
+        self.accel = np.array([0.0, 0.0, 0.0])
         self.imu_orientation = Quaternion(w=1.0)
 
         # Falling odometry / imu interpolation during falls

--- a/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/localization_blackboard.py
+++ b/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/localization_blackboard.py
@@ -112,10 +112,10 @@ class LocalizationBlackboard:
     def get_imu_yaw(self) -> float:
         """Returns the current yaw of the IMU (this is not an absolute measurement!!! It drifts over time!)"""
 
-        return quat2euler(xyzw2wxyz(numpify(self.imu_orientation)), axes="szxy")[2]
+        return quat2euler(xyzw2wxyz(numpify(self.imu_orientation)), axes="szxy")[0]
 
     def get_localization_yaw(self) -> float:
         """Returns the current yaw of the robot according to the localization. 0 is the x-axis of the field."""
         if self.robot_pose is None:
             return 0.0
-        return quat2euler(xyzw2wxyz(numpify(self.robot_pose.pose.pose.orientation)), axes="szxy")[2]
+        return quat2euler(xyzw2wxyz(numpify(self.robot_pose.pose.pose.orientation)), axes="szxy")[0]

--- a/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/localization_blackboard.py
+++ b/bitbots_navigation/bitbots_localization_handler/bitbots_localization_handler/localization_dsd/localization_blackboard.py
@@ -2,8 +2,9 @@ import numpy as np
 import tf2_ros as tf2
 from bitbots_blackboard.capsules.game_status_capsule import GameStatusCapsule
 from bitbots_localization.srv import ResetFilter, SetPaused
+from bitbots_utils.transforms import quat2euler, xyzw2wxyz
 from bitbots_utils.utils import get_parameters_from_other_node
-from geometry_msgs.msg import PoseWithCovarianceStamped
+from geometry_msgs.msg import PoseWithCovarianceStamped, Quaternion
 from rclpy.duration import Duration
 from rclpy.node import Node
 from ros2_numpy import numpify
@@ -50,8 +51,14 @@ class LocalizationBlackboard:
         # Was the last robot state one of the get up states?
         self.last_state_get_up = False
 
-        # Picked up
+        # IMU
         self.accel = np.array([0, 0, 0])
+        self.imu_orientation = Quaternion(w=1.0)
+
+        # Falling odometry / imu interpolation during falls
+        self.imu_yaw_before_fall: float = 0.0
+
+        # Picked up
         self.pickup_accel_buffer = []
         self.pickup_accel_buffer_long = []
 
@@ -76,6 +83,7 @@ class LocalizationBlackboard:
 
     def _callback_imu(self, msg: Imu):
         self.accel = numpify(msg.linear_acceleration)
+        self.imu_orientation = msg.orientation
 
         if self.robot_control_state is not None and self.robot_control_state not in [
             RobotControlState.FALLEN,
@@ -100,3 +108,14 @@ class LocalizationBlackboard:
         absolute_diff = abs(mean_long - mean)
 
         return absolute_diff > 1.0
+
+    def get_imu_yaw(self) -> float:
+        """Returns the current yaw of the IMU (this is not an absolute measurement!!! It drifts over time!)"""
+
+        return quat2euler(xyzw2wxyz(numpify(self.imu_orientation)), axes="szxy")[2]
+
+    def get_localization_yaw(self) -> float:
+        """Returns the current yaw of the robot according to the localization. 0 is the x-axis of the field."""
+        if self.robot_pose is None:
+            return 0.0
+        return quat2euler(xyzw2wxyz(numpify(self.robot_pose.pose.pose.orientation)), axes="szxy")[2]

--- a/bitbots_navigation/bitbots_localization_handler/package.xml
+++ b/bitbots_navigation/bitbots_localization_handler/package.xml
@@ -23,6 +23,7 @@
   <depend>geometry_msgs</depend>
   <depend>python3-numpy</depend>
   <depend>rclpy</depend>
+  <depend>ros2_numpy</depend>
   <depend>std_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>


### PR DESCRIPTION
# Summary
Store IMU orientation when we fall. Check the IMU yaw after the fall and estimate how much the robot has rotated during the fall. This leads to a better re-initialization especially when we fall on ambiguous locations like the center point.

## Proposed changes
- Store imu yaw 
- Reinit based on change in imu yaw

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
