### PR TITLE
Fix missing joint states in animation server

### DIFF
--- a/bitbots_motion/bitbots_animation_server/bitbots_animation_server/animation_node.py
+++ b/bitbots_motion/bitbots_animation_server/bitbots_animation_server/animation_node.py
@@ -168,6 +168,10 @@ class AnimationNode(Node):
                 num_tries += 1
                 self.get_clock().sleep_for(Duration(seconds=0.1))
 
+        # Make sure we have our current joint states
+        while rclpy.ok() and self.current_joint_states is None:
+            self.get_clock().sleep_for(Duration(seconds=0.1))
+
         # Create splines
         animator = SplineAnimator(
             self.animation_cache[self.current_animation], self.current_joint_states, self.get_logger(), self.get_clock()

--- a/bitbots_motion/bitbots_animation_server/bitbots_animation_server/spline_animator.py
+++ b/bitbots_motion/bitbots_animation_server/bitbots_animation_server/spline_animator.py
@@ -19,10 +19,6 @@ class SplineAnimator:
         self.torques = {}
         self.keyframe_times: list[float] = []
 
-        # Add current joint positions as start
-        if current_joint_states is None:
-            logger.warn("No current joint positions. Will play animation starting from first keyframe.")
-
         # Load keyframe positions into the splines
         current_point_time = 0.0
         for keyframe in self.anim.keyframes:
@@ -36,15 +32,14 @@ class SplineAnimator:
                 if joint not in self.spline_dict:
                     # If not, create a new spline
                     self.spline_dict[joint] = SmoothSpline()
-                    # Add the current joint position (if available) as the first point
-                    if current_joint_states is not None:
-                        # Get the number of the joint in the joint_states message
-                        joint_index = current_joint_states.name.index(joint)
-                        # Add the current joint position as the point before the first keyframe
-                        self.spline_dict[joint].add_point(
-                            current_point_time - keyframe.duration,
-                            math.degrees(current_joint_states.position[joint_index]),
-                        )
+                    # Add the current joint position as the first point
+                    # Get the number of the joint in the joint_states message
+                    joint_index = current_joint_states.name.index(joint)
+                    # Add the current joint position as the point before the first keyframe
+                    self.spline_dict[joint].add_point(
+                        current_point_time - keyframe.duration,
+                        math.degrees(current_joint_states.position[joint_index]),
+                    )
                 # Add the keyframe position as the next point
                 self.spline_dict[joint].add_point(current_point_time, keyframe.goals[joint])
                 # Add a second point if we want to hold the position for a while


### PR DESCRIPTION
# Summary
Follow-up on #407, fix animation server dying when `init` animation is launched very early, before ros control startup is finished.