### PR TITLE
Limit unrealistically large motion updates

### DIFF
--- a/bitbots_navigation/bitbots_localization/config/config.yaml
+++ b/bitbots_navigation/bitbots_localization/config/config.yaml
@@ -5,6 +5,8 @@ bitbots_localization:
       percentage_best_particles: 50
       min_motion_linear: 0.0
       min_motion_angular: 0.0
+      max_motion_linear: 0.5
+      max_motion_angular: 3.14
       filter_only_with_motion: false
     ros:
       line_pointcloud_topic: 'line_mask_relative_pc'

--- a/bitbots_navigation/bitbots_localization/src/parameters.yml
+++ b/bitbots_navigation/bitbots_localization/src/parameters.yml
@@ -14,22 +14,22 @@ bitbots_localization:
       type: double
       description: "Minimum linear motion (m/s) which is considered to be a movement. This is relevant if we want to deactivate the filter if no movement is detected"
       validation:
-        bounds<>: [0.0, 1.0]
+        gt_eq<>: [0.0]
     max_motion_linear:
       type: double
       description: "Maximum linear motion (m/s) which is considered to be a movement. Updates larger than this are deemed unrealistic and are ignored"
       validation:
-        bounds<>: [0.0, 1.0]
+        gt_eq<>: [0.0]
     min_motion_angular:
       type: double
       description: "Minimum angular motion (rad/s) which is considered to be a movement. This is relevant if we want to deactivate the filter if no movement is detected"
       validation:
-        bounds<>: [0.0, 1.0]
+        gt_eq<>: [0.0]
     max_motion_angular:
       type: double
       description: "Maximum angular motion (rad/s) which is considered to be a movement. Updates larger than this are deemed unrealistic and are ignored"
       validation:
-        bounds<>: [0.0, 1.0]
+        gt_eq<>: [0.0]
     filter_only_with_motion:
       type: bool
       description: "If true, the filter is only active if a movement is detected"

--- a/bitbots_navigation/bitbots_localization/src/parameters.yml
+++ b/bitbots_navigation/bitbots_localization/src/parameters.yml
@@ -1,6 +1,6 @@
 bitbots_localization:
   misc:
-    init_mode: 
+    init_mode:
       type: int
       description: "Initialization mode for the filters particle distribution"
       validation:
@@ -15,9 +15,19 @@ bitbots_localization:
       description: "Minimum linear motion (m/s) which is considered to be a movement. This is relevant if we want to deactivate the filter if no movement is detected"
       validation:
         bounds<>: [0.0, 1.0]
+    max_motion_linear:
+      type: double
+      description: "Maximum linear motion (m/s) which is considered to be a movement. Updates larger than this are deemed unrealistic and are ignored"
+      validation:
+        bounds<>: [0.0, 1.0]
     min_motion_angular:
       type: double
       description: "Minimum angular motion (rad/s) which is considered to be a movement. This is relevant if we want to deactivate the filter if no movement is detected"
+      validation:
+        bounds<>: [0.0, 1.0]
+    max_motion_angular:
+      type: double
+      description: "Maximum angular motion (rad/s) which is considered to be a movement. Updates larger than this are deemed unrealistic and are ignored"
       validation:
         bounds<>: [0.0, 1.0]
     filter_only_with_motion:
@@ -171,7 +181,7 @@ bitbots_localization:
         validation:
           bounds<>: [-5.0, 5.0]
     scoring:
-      lines: 
+      lines:
         factor:
           type: double
           description: "Weighing how much the line information is considered for the scoring of a particle"


### PR DESCRIPTION
# Summary
If e.g. during a fall a large rotation is output by the odometry or if a component like the odometry is reseted the localization should ignore the motion update as it otherwise leads to "exploding particles" because the unrealistically large updates leads to a lot of added noise.

## Proposed changes
- Add parameters with a max velocity for the motion updates

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
