### PR TITLE
test(path_planning): fix tests for new filter

### DIFF
--- a/bitbots_navigation/bitbots_path_planning/bitbots_path_planning/controller.py
+++ b/bitbots_navigation/bitbots_path_planning/bitbots_path_planning/controller.py
@@ -166,7 +166,8 @@ class Controller:
 
             # Calculate the exponential decay smoothing factor alpha from the time constant tau
             # Instead of defining alpha directly, we use tau to derive it in a time-step independent way
-            alpha = 1 - math.exp(-delta_time.nanoseconds / (self.config_smoothing_tau * 1e9))
+            exponent_in_s = -delta_time.nanoseconds / (self.config_smoothing_tau * 1e9)
+            alpha = 1 - math.exp(exponent_in_s)
 
             # Apply the exponential moving average filter
             cmd_vel.linear.x = alpha * cmd_vel.linear.x + (1 - alpha) * self.last_cmd_vel.linear.x

--- a/bitbots_navigation/bitbots_path_planning/test/__snapshots__/test_controller.ambr
+++ b/bitbots_navigation/bitbots_path_planning/test/__snapshots__/test_controller.ambr
@@ -10,10 +10,10 @@
     'config_orient_to_goal_distance': 1.0,
     'config_rotation_i_factor': 0.05,
     'config_rotation_slow_down_factor': 0.3,
-    'config_smoothing_k': 0.2,
+    'config_smoothing_tau': 0.2,
     'config_translation_slow_down_factor': 0.5,
   })
 # ---
 # name: test_step_cmd_vel_smoothing
-  'geometry_msgs.msg.Twist(linear=geometry_msgs.msg.Vector3(x=0.18500000000000003, y=0.08, z=0.0), angular=geometry_msgs.msg.Vector3(x=0.0, y=0.0, z=0.30290045562082435))'
+  'geometry_msgs.msg.Twist(linear=geometry_msgs.msg.Vector3(x=0.1375935868207597, y=0.08, z=0.0), angular=geometry_msgs.msg.Vector3(x=0.0, y=0.0, z=0.2320828999230522))'
 # ---


### PR DESCRIPTION
Fixes broken `path_planning` tests on main.
For new time based exponential moving average filter.

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
