### PR TITLE
Bump CI actions to resolve warning about deprecated node.js 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ros-tooling/setup-ros@v0.7
 
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure git to trust repository
         run: git config --global --add safe.directory /__w/bitbots_main/bitbots_main


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
Updates CI workflow and thereby resolves Action warnings

## Proposed changes
<!--- Describe your changes and why they are necessary. -->
- Bump `ros-tooling/setup-ros@v0.7` -> `ros-tooling/setup-ros@v0.7`
- Bump `actions/checkout@v3` -> `actions/checkout@v4`

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: ros-tooling/setup-ros@v0.7, actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
