### PR TITLE
Remove scaling for sole to base

### DIFF
--- a/bitbots_motion/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_motion/bitbots_odometry/src/motion_odometry.cpp
@@ -109,13 +109,8 @@ void MotionOdometry::loop() {
     tf2::Transform current_support_to_base;
     tf2::fromMsg(current_support_to_base_msg.transform, current_support_to_base);
     double x = current_support_to_base.getOrigin().x();
-    if (current_odom_msg_.twist.twist.linear.x > 0) {
-      x = x * config_.x_forward_scaling;
-    } else {
-      x = x * config_.x_backward_scaling;
-    }
-    double y = current_support_to_base.getOrigin().y() * config_.y_scaling;
-    double yaw = tf2::getYaw(current_support_to_base.getRotation()) * config_.yaw_scaling;
+    double y = current_support_to_base.getOrigin().y();
+    double yaw = tf2::getYaw(current_support_to_base.getRotation());
     current_support_to_base.setOrigin({x, y, current_support_to_base.getOrigin().z()});
     tf2::Quaternion q;
     q.setRPY(0, 0, yaw);


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
It may not be useful to scale the transform from one foot to the other with the same factors as the support sole to the base.
Additionally, the transform from support foot to base might not have to be scaled at all.
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
Remove the scaling factor from sole to base.
## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
