### PR TITLE
Fix artifact of team comm move

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,8 @@ fresh-libs: remove-libs setup-libs
 remove-libs:
 	# Removes the lib directory and all its contents
 	rm -rf lib/*
+	# Also remove the generated protobuf files, as they are not needed anymore
+	rm bitbots_team_communication/bitbots_team_communication/robocup_extension_pb2.py 2> /dev/null || true
 
 setup-libs:
 	# Clone lib repositories in workspace.repos into the lib directory


### PR DESCRIPTION
# Summary
A protobuf related git ignored file might still be present at the old team com location. `make fresh-libs` now clears that

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [x] Run `colcon build`
- [x] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [x] Create issues for future work
- [x] Triage this PR and label it
