### PR TITLE
Fix start movement in walking

### DIFF
--- a/bitbots_motion/bitbots_quintic_walk/src/walk_engine.cpp
+++ b/bitbots_motion/bitbots_quintic_walk/src/walk_engine.cpp
@@ -638,7 +638,12 @@ void WalkEngine::buildTrajectories(bool start_movement, bool start_step, bool ki
     trunk_spline_.y()->addPoint(0.0, trunk_pos_at_foot_change_.y(), trunk_pos_vel_at_foot_change_.y(),
                                 trunk_pos_acc_at_foot_change_.y());
   }
-  if (start_step || start_movement) {
+  if (start_movement) {
+    trunk_spline_.y()->addPoint(period + time_shift - pause_length,
+                                trunk_point_middle.y() - trunk_vect.y() * config_.first_step_swing_factor);
+    trunk_spline_.y()->addPoint(period + time_shift + pause_length,
+                                trunk_point_middle.y() - trunk_vect.y() * config_.first_step_swing_factor);
+  } else if (start_step) {
     trunk_spline_.y()->addPoint(half_period + time_shift - pause_length,
                                 trunk_point_middle.y() + trunk_vect.y() * config_.first_step_swing_factor);
     trunk_spline_.y()->addPoint(half_period + time_shift + pause_length,


### PR DESCRIPTION
# Summary
Fixes the start movement in walking. Before, there was a jump in the trajectory for both feet's y axis when starting the first step.

Before:
![image](https://github.com/bit-bots/bitbots_main/assets/25013222/65860abd-47eb-4c02-a856-781273d3631a)

After:
![Screenshot from 2024-06-20 15-49-13](https://github.com/bit-bots/bitbots_main/assets/25013222/d345e973-1571-4d5f-8425-be56cac00650)

- [x] tested in visualization
- [ ] tested on robot