### PR TITLE
Always publish debug messages

### DIFF
--- a/bitbots_motion/bitbots_quintic_walk/src/walk_node.cpp
+++ b/bitbots_motion/bitbots_quintic_walk/src/walk_node.cpp
@@ -185,12 +185,11 @@ void WalkNode::run() {
           pub_support_->publish(support_state);
           current_support_foot_ = support_state.phase;
         }
-
-        // publish debug information
-        if (config_.node.debug_active) {
-          publish_debug();
-        }
       }
+    }
+    // publish debug information
+    if (config_.node.debug_active) {
+      publish_debug();
     }
     // always publish odometry to not confuse odometry fuser
     pub_odometry_->publish(getOdometry());

--- a/bitbots_motion/bitbots_quintic_walk/src/walk_visualizer.cpp
+++ b/bitbots_motion/bitbots_quintic_walk/src/walk_visualizer.cpp
@@ -329,6 +329,10 @@ void WalkVisualizer::publishArrowMarker(std::string name_space, std::string fram
 }
 
 void WalkVisualizer::publishWalkMarkers(WalkResponse response) {
+  // only do something if someone is listing
+  if (pub_debug_marker_->get_subscription_count() == 0) {
+    return;
+  }
   // publish markers
   visualization_msgs::msg::Marker marker_msg;
   marker_msg.header.stamp = node_->now();


### PR DESCRIPTION
# Summary
The walking should always publish its debug messages, even when it's idle. This makes it much easier to debug the walking's start and stop movements. It also does not add an overhead in normal use because the debug messages are only published when there is a subscriber.

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
