### PR TITLE
Add falling to rise portion of dynup

### DIFF
--- a/bitbots_motion/bitbots_dynup/src/dynup_engine.cpp
+++ b/bitbots_motion/bitbots_dynup/src/dynup_engine.cpp
@@ -747,17 +747,15 @@ bool DynupEngine::isStabilizingNeeded() {
 }
 
 bool DynupEngine::isHeadZero() {
-  // set heads zero in the middle of rise phase
+  // set heads zero if we are upright
   return (((direction_ == DynupDirection::FRONT or direction_ == DynupDirection::FRONT_ONLY) and
            time_ >= params_.dynup_front.time_hands_side + params_.dynup_front.time_hands_rotate +
                         params_.dynup_front.time_foot_close + params_.dynup_front.time_hands_front +
                         params_.dynup_front.time_foot_ground_front + params_.dynup_front.time_torso_45 +
-                        params_.dynup_front.time_to_squat + params_.dynup_front.wait_in_squat_front +
-                        0.5 * params_.rise.rise_time) or
+                        params_.dynup_front.time_to_squat) or
           ((direction_ == DynupDirection::BACK or direction_ == DynupDirection::BACK_ONLY) and
            time_ >= params_.dynup_back.time_legs_close + params_.dynup_back.time_foot_ground_back +
-                        params_.dynup_back.time_full_squat_hands + params_.dynup_back.time_full_squat_legs +
-                        params_.dynup_back.wait_in_squat_back + 0.5 * params_.rise.rise_time) or
+                        params_.dynup_back.time_full_squat_hands + params_.dynup_back.time_full_squat_legs) or
           (direction_ == DynupDirection::RISE) or (direction_ == DynupDirection::DESCEND));
 }
 

--- a/bitbots_motion/bitbots_dynup/src/dynup_ik.cpp
+++ b/bitbots_motion/bitbots_dynup/src/dynup_ik.cpp
@@ -82,18 +82,16 @@ bitbots_splines::JointGoals DynupIK::calculate(const DynupResponse &ik_goals) {
       } else if (result.first[i] == "HeadTilt") {
         if (ik_goals.is_head_zero) {
           result.second[i] = 0;
+        } else if (direction_ == DynupDirection::FRONT or direction_ == DynupDirection::FRONT_ONLY) {
+          result.second[i] = 1.0;
+        } else if (direction_ == DynupDirection::BACK or direction_ == DynupDirection::BACK_ONLY) {
+          result.second[i] = -1.5;
+        } else if (direction_ == DynupDirection::WALKREADY) {
+          // remove head from the goals so that we can move it freely
+          result.first.erase(result.first.begin() + i);
+          result.second.erase(result.second.begin() + i);
         } else {
-          if (direction_ == DynupDirection::FRONT or direction_ == DynupDirection::FRONT_ONLY) {
-            result.second[i] = 1.0;
-          } else if (direction_ == DynupDirection::BACK or direction_ == DynupDirection::BACK_ONLY) {
-            result.second[i] = -1.5;
-          } else if (direction_ == DynupDirection::WALKREADY) {
-            // remove head from the goals so that we can move it freely
-            result.first.erase(result.first.begin() + i);
-            result.second.erase(result.second.begin() + i);
-          } else {
-            result.second[i] = 0;
-          }
+          result.second[i] = 0;
         }
       }
     }

--- a/bitbots_motion/bitbots_dynup/src/dynup_node.cpp
+++ b/bitbots_motion/bitbots_dynup/src/dynup_node.cpp
@@ -268,7 +268,7 @@ void DynupNode::loopEngine(int loop_rate, std::shared_ptr<DynupGoalHandle> goal_
       return;
     }
     if (msg.joint_names.empty()) {
-      break;
+      continue;
     }
     joint_goal_publisher_->publish(msg);
     node_->get_clock()->sleep_until(startTime + rclcpp::Duration::from_nanoseconds(1e9 / loop_rate));

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/play_animation.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/play_animation.py
@@ -185,10 +185,9 @@ class PlayAnimationDynup(AbstractHCMActionElement):
         Cancel the current goal when the action is popped
         """
         super().on_pop()
-        self.blackboard.node.get_logger().warn("Canceling dynup action")
         if not self.animation_finished():
             self.blackboard.dynup_action_current_goal.result().cancel_goal_async()
-            self.blackboard.node.get_logger().warn("Canceling dynup action successful")
+            self.blackboard.node.get_logger().info("Canceling dynup")
 
     def start_animation(self):
         """

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/play_animation.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/play_animation.py
@@ -179,7 +179,7 @@ class PlayAnimationDynup(AbstractHCMActionElement):
         if self.animation_finished():
             # we are finished playing this animation
             return self.pop()
-    
+
     def on_pop(self):
         """
         Cancel the current goal when the action is popped

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/play_animation.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/play_animation.py
@@ -152,8 +152,14 @@ class PlayAnimationDynup(AbstractHCMActionElement):
         self.first_perform = True
 
     def perform(self, reevaluate=False):
-        # deactivate falling since it will be wrongly detected
-        self.do_not_reevaluate()
+        # Deactivate do not interrupt certain actions due to e.g. the falling detection, because we might be in an unstable state
+        if self.direction in [
+            Dynup.Goal.DIRECTION_FRONT,
+            Dynup.Goal.DIRECTION_BACK,
+            Dynup.Goal.DIRECTION_FRONT_ONLY,
+            Dynup.Goal.DIRECTION_BACK_ONLY,
+        ]:
+            self.do_not_reevaluate()
 
         # We only want to execute this once
         if self.first_perform:
@@ -173,6 +179,16 @@ class PlayAnimationDynup(AbstractHCMActionElement):
         if self.animation_finished():
             # we are finished playing this animation
             return self.pop()
+    
+    def on_pop(self):
+        """
+        Cancel the current goal when the action is popped
+        """
+        super().on_pop()
+        self.blackboard.node.get_logger().warn("Canceling dynup action")
+        if not self.animation_finished():
+            self.blackboard.dynup_action_current_goal.result().cancel_goal_async()
+            self.blackboard.node.get_logger().warn("Canceling dynup action successful")
 
     def start_animation(self):
         """

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/squat.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/squat.py
@@ -1,0 +1,21 @@
+
+from bitbots_hcm.hcm_dsd.actions import AbstractHCMActionElement
+
+class SetSquat(AbstractHCMActionElement):
+    """
+    Tells the blackboard that we are squatting or not.
+    """
+
+    def __init__(self, blackboard, dsd, parameters):
+        super().__init__(blackboard, dsd, parameters)
+
+        # Check if parameters are valid
+        assert "squat" in parameters, "No squat parameter given"
+        assert type(parameters["squat"]) == bool, "Squat parameter is not a bool"
+
+        # Set state in blackboard
+        self.blackboard.in_squat = parameters["squat"]
+
+    def perform(self, reevaluate=False):
+        # Our job is done, we can pop
+        self.pop()

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/squat.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/squat.py
@@ -1,5 +1,5 @@
-
 from bitbots_hcm.hcm_dsd.actions import AbstractHCMActionElement
+
 
 class SetSquat(AbstractHCMActionElement):
     """
@@ -11,7 +11,7 @@ class SetSquat(AbstractHCMActionElement):
 
         # Check if parameters are valid
         assert "squat" in parameters, "No squat parameter given"
-        assert type(parameters["squat"]) == bool, "Squat parameter is not a bool"
+        assert isinstance(parameters["squat"], bool), "Squat parameter is not a boolean"
 
         # Set state in blackboard
         self.blackboard.in_squat = parameters["squat"]

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/decisions/squat.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/decisions/squat.py
@@ -1,0 +1,16 @@
+from bitbots_hcm.hcm_dsd.decisions import AbstractHCMDecisionElement
+
+
+class InSquat(AbstractHCMDecisionElement):
+    """
+    Decides if the robot is currently recording animations
+    """
+
+    def perform(self, reevaluate=False):
+        if self.blackboard.in_squat:
+            return "YES"
+        else:
+            return "NO"
+
+    def get_reevaluate(self):
+        return True

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm.dsd
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm.dsd
@@ -1,21 +1,21 @@
 -->HCM
 $StartHCM
     START_UP --> $Simulation
-        YES --> @RobotStateStartup, @PlayAnimationDynup + direction:walkready
-        NO --> @RobotStateStartup, @PlayAnimationInit, @PlayAnimationDynup + direction:walkready
+        YES --> @RobotStateStartup, @PlayAnimationDynup + direction:walkready + r:false
+        NO --> @RobotStateStartup, @PlayAnimationInit, @PlayAnimationDynup + direction:walkready + r:false
     RUNNING --> $CheckMotors
         MOTORS_NOT_STARTED --> @RobotStateStartup, @Wait
         OVERLOAD --> @RobotStateMotorOff, @CancelGoals, @StopWalking, @PlayAnimationFallingFront, @TurnMotorsOff, @Wait
         PROBLEM --> @RobotStateHardwareProblem, @WaitForMotors
-        TURN_ON --> @TurnMotorsOn, @PlayAnimationDynup + direction:walkready, @Wait
+        TURN_ON --> @TurnMotorsOn, @PlayAnimationDynup + direction:walkready + r:false, @Wait
         OKAY --> $RecordAnimation
             RECORD_ACTIVE --> @RobotStateRecord, @Wait
             FREE --> $TeachingMode
                 TEACH --> @RobotStateRecord, @SetTorque + stiff:false, @Wait
                 HOLD --> @SetTorque + stiff:true, @Wait
-                FINISHED --> @SetTorque + stiff:true + r:false, @RobotStateControllable, @PlayAnimationDynup + direction:walkready
+                FINISHED --> @SetTorque + stiff:true + r:false, @RobotStateControllable, @PlayAnimationDynup + direction:walkready + r:false
                 OFF -->  $Stop
-                    STOPPED --> @RobotStatePenalty, @CancelGoals, @StopWalking, @PlayAnimationDynup + direction:walkready, @Wait
+                    STOPPED --> @RobotStatePenalty, @CancelGoals, @StopWalking, @PlayAnimationDynup + direction:walkready + r:false, @Wait
                     FREE -->$CheckIMU
                         IMU_NOT_STARTED --> @RobotStateStartup, @WaitForIMUStartup
                         PROBLEM --> @RobotStateHardwareProblem, @WaitForIMU
@@ -23,10 +23,10 @@ $StartHCM
                             PRESSURE_NOT_STARTED --> @RobotStateStartup, @WaitForPressureStartup
                             PROBLEM --> @RobotStateHardwareProblem, @WaitForPressure
                             OKAY --> $PickedUp
-                                PICKED_UP --> @RobotStatePickedUp, @PlayAnimationDynup + direction:walkready, @Wait
+                                PICKED_UP --> @RobotStatePickedUp, @PlayAnimationDynup + direction:walkready + r:false, @Wait
                                 ON_GROUND --> $Fallen
-                                    FALLEN_FRONT --> @RobotStateFallen, @CancelGoals, @StopWalking, @RobotStateGettingUp, @PlayAnimationDynup + direction:front
-                                    FALLEN_BACK --> @RobotStateFallen, @CancelGoals, @StopWalking, @RobotStateGettingUp, @SetFootZero, @PlayAnimationDynup + direction:back
+                                    FALLEN_FRONT --> @RobotStateFallen, @CancelGoals, @StopWalking, @RobotStateGettingUp, @PlayAnimationDynup + direction:front_only, @SetSquat + squat:true
+                                    FALLEN_BACK --> @RobotStateFallen, @CancelGoals, @StopWalking, @RobotStateGettingUp, @SetFootZero, @PlayAnimationDynup + direction:back_only, @SetSquat + squat:true
                                     FALLEN_RIGHT --> @RobotStateFallen, @CancelGoals, @StopWalking, @PlayAnimationTurningBackRight
                                     FALLEN_LEFT --> @RobotStateFallen, @CancelGoals, @StopWalking, @PlayAnimationTurningBackLeft
                                     NOT_FALLEN --> $Falling
@@ -34,11 +34,13 @@ $StartHCM
                                         FALLING_RIGHT --> @RobotStateFalling, @CancelGoals, @StopWalking, @PlayAnimationFallingRight, @Wait
                                         FALLING_FRONT --> @RobotStateFalling, @CancelGoals, @StopWalking, @PlayAnimationFallingFront, @Wait
                                         FALLING_BACK --> @RobotStateFalling, @CancelGoals, @StopWalking, @PlayAnimationFallingBack, @Wait
-                                        NOT_FALLING --> $PlayingExternalAnimation
-                                            ANIMATION_RUNNING --> @StopWalking, @RobotStateAnimationRunning, @Wait
-                                            ANIMATION_SERVER_TIMEOUT --> @CancelAnimation
-                                            FREE --> $RecentWalkingGoals
-                                                STAY_WALKING --> @RobotStateWalking, @Wait
-                                                NOT_WALKING --> $RecentKickGoals
-                                                    KICKING --> @RobotStateKicking, @Wait
-                                                    NOT_KICKING --> @RobotStateControllable, @Wait
+                                        NOT_FALLING --> $InSquat
+                                            YES --> @RobotStateGettingUp, @PlayAnimationDynup + direction:rise, @SetSquat + squat:false
+                                            NO --> $PlayingExternalAnimation
+                                                ANIMATION_RUNNING --> @StopWalking, @RobotStateAnimationRunning, @Wait
+                                                ANIMATION_SERVER_TIMEOUT --> @CancelAnimation
+                                                FREE --> $RecentWalkingGoals
+                                                    STAY_WALKING --> @RobotStateWalking, @Wait
+                                                    NOT_WALKING --> $RecentKickGoals
+                                                        KICKING --> @RobotStateKicking, @Wait
+                                                        NOT_KICKING --> @RobotStateControllable, @Wait

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm_blackboard.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm_blackboard.py
@@ -94,6 +94,7 @@ class HcmBlackboard:
         # Paramerters
         self.is_stand_up_active = self.node.get_parameter("stand_up_active").value
         self.falling_detection_active = self.node.get_parameter("falling_active").value
+        self.in_squat: bool = False  # Needed for sequencing of the stand up motion
 
         # Kicking
         # State


### PR DESCRIPTION
# Summary

Allow falling detection in `Descent`, `Rise` and `Walkready` dynup targets. To utilize that the HCM standup now calls the dynup twice, once for each portion.

Depends on https://github.com/bit-bots/dynamic_stack_decider/pull/110

## Checklist

- [x] Run `colcon build`
- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [x] Create issues for future work
- [ ] Triage this PR and label it
