### PR TITLE
ros_control: add delay before motor write after power is turned on

### DIFF
--- a/bitbots_lowlevel/bitbots_ros_control/config/wolfgang.yaml
+++ b/bitbots_lowlevel/bitbots_ros_control/config/wolfgang.yaml
@@ -37,6 +37,7 @@ wolfgang_hardware_interface:
       auto_torque: true
 
       set_ROM_RAM: true # set the following values on startup to all motors
+      start_delay: 0.5 # delay after the motors are turned on until values are written, in seconds
 
       ROM_RAM_DEFAULT:
         # all names of parameters have to be the same as on the dynamixel table (see dynamixel_workbench_toolbox/src/dynamixel_item.cpp )

--- a/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/wolfgang_hardware_interface.hpp
+++ b/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/wolfgang_hardware_interface.hpp
@@ -33,6 +33,8 @@ class WolfgangHardwareInterface {
   std::vector<std::vector<bitbots_ros_control::HardwareInterface *>> interfaces_;
   DynamixelServoHardwareInterface servo_interface_;
   rclcpp::Publisher<bitbots_msgs::msg::Audio>::SharedPtr speak_pub_;
+  rclcpp::Time motor_start_time_;
+  bool motor_first_write_{false};
 
   // prevent unnecessary error when power is turned on
   bool first_ping_error_;


### PR DESCRIPTION
# Summary
This is necessary because the motors need some time for their startup. When ROM/RAM values are written directly after startup, they don't take effect. The start_delay parameter is added to set this delay. From testing, a value of 10ms would be sufficient but I chose a higher value to be on the safe side and because this is only rarely executed.

## Related issues
This was a problem before because custom PID values were not set after the motor power was turned off, leading to worse performance of the walking and standup.

## Checklist
- [x] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
