### PR TITLE
ros_control: write motor values before power is cycled the first time

### DIFF
--- a/bitbots_lowlevel/bitbots_ros_control/src/wolfgang_hardware_interface.cpp
+++ b/bitbots_lowlevel/bitbots_ros_control/src/wolfgang_hardware_interface.cpp
@@ -304,7 +304,7 @@ void WolfgangHardwareInterface::write(const rclcpp::Time &t, const rclcpp::Durat
     motor_start_time_ = t + rclcpp::Duration::from_seconds(nh_->get_parameter("servos.start_delay").as_double());
     motor_first_write_ = true;
   }
-  if (motor_start_time_ && t > motor_start_time_) {
+  if (!motor_start_time_ || t > motor_start_time_.value()) {
     if (motor_first_write_) {
       servo_interface_.writeROMRAM(false);
       motor_first_write_ = false;


### PR DESCRIPTION
# Summary
Follow-up on #515, the motors should be written also when motor_start_time_ is not set yet.