### PR TITLE
ros_control: new method to restore functionality after power cycle

### DIFF
--- a/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/hardware_interface.hpp
+++ b/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/hardware_interface.hpp
@@ -16,6 +16,8 @@ class HardwareInterface {
 
   virtual void write(const rclcpp::Time &t, const rclcpp::Duration &dt){};
 
+  virtual void restoreAfterPowerCycle(){};
+
   virtual ~HardwareInterface(){};
 };
 }  // namespace bitbots_ros_control

--- a/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/imu_hardware_interface.hpp
+++ b/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/imu_hardware_interface.hpp
@@ -25,6 +25,7 @@ class ImuHardwareInterface : public bitbots_ros_control::HardwareInterface {
   bool init();
   void read(const rclcpp::Time &t, const rclcpp::Duration &dt);
   void write(const rclcpp::Time &t, const rclcpp::Duration &dt);
+  void restoreAfterPowerCycle();
 
  private:
   rclcpp::Node::SharedPtr nh_;

--- a/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/servo_bus_interface.hpp
+++ b/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/servo_bus_interface.hpp
@@ -27,6 +27,7 @@ class ServoBusInterface : public bitbots_ros_control::HardwareInterface {
   bool init();
   void read(const rclcpp::Time &t, const rclcpp::Duration &dt);
   void write(const rclcpp::Time &t, const rclcpp::Duration &dt);
+  void restoreAfterPowerCycle();
 
   bool loadDynamixels();
   bool writeROMRAM(bool first_time);

--- a/bitbots_lowlevel/bitbots_ros_control/src/imu_hardware_interface.cpp
+++ b/bitbots_lowlevel/bitbots_ros_control/src/imu_hardware_interface.cpp
@@ -306,4 +306,6 @@ void ImuHardwareInterface::write(const rclcpp::Time &t, const rclcpp::Duration &
     set_accel_calib_threshold_ = false;
   }
 }
+
+void ImuHardwareInterface::restoreAfterPowerCycle() { write_complementary_filter_params_ = true; }
 }  // namespace bitbots_ros_control

--- a/bitbots_lowlevel/bitbots_ros_control/src/servo_bus_interface.cpp
+++ b/bitbots_lowlevel/bitbots_ros_control/src/servo_bus_interface.cpp
@@ -401,6 +401,8 @@ void ServoBusInterface::write(const rclcpp::Time &t, const rclcpp::Duration &dt)
   lost_servo_connection_ = false;
 }
 
+void ServoBusInterface::restoreAfterPowerCycle() { writeROMRAM(false); }
+
 void ServoBusInterface::switchDynamixelControlMode() {
   /**
    * This method switches the control mode of all servos

--- a/bitbots_lowlevel/bitbots_ros_control/src/wolfgang_hardware_interface.cpp
+++ b/bitbots_lowlevel/bitbots_ros_control/src/wolfgang_hardware_interface.cpp
@@ -306,7 +306,11 @@ void WolfgangHardwareInterface::write(const rclcpp::Time &t, const rclcpp::Durat
   }
   if (motor_start_time_ && t > motor_start_time_) {
     if (motor_first_write_) {
-      servo_interface_.writeROMRAM(false);
+      for (std::vector<HardwareInterface *> &port_interfaces : interfaces_) {
+        for (HardwareInterface *interface : port_interfaces) {
+          interface->restoreAfterPowerCycle();
+        }
+      }
       motor_first_write_ = false;
     }
     if (core_present_ && !current_power_status_) {


### PR DESCRIPTION
# Summary
This method is called when a power cycle happens, it restores the servos' ROM and the IMU parameters.