### PR TITLE
Deploytool: Fix wrong warnings and small improvements

### DIFF
--- a/scripts/deploy/deploy_robots.py
+++ b/scripts/deploy/deploy_robots.py
@@ -174,8 +174,7 @@ class DeployRobots:
         """
         tasks = []
 
-        if not self._args.skip_local_repo_check:
-            tasks.append(CheckReposTask())
+        tasks.append(CheckReposTask(only_workspace_status=self._args.skip_local_repo_check))
 
         if self._args.sync:
             tasks.append(

--- a/scripts/deploy/tasks/build.py
+++ b/scripts/deploy/tasks/build.py
@@ -82,7 +82,6 @@ class Build(AbstractTask):
             "sync;"
         )
         # TODO make output colored
-        # TODO: check if only single core?!?
 
         print_debug(f"Calling {cmd}")
         try:

--- a/scripts/deploy/tasks/check_repos.py
+++ b/scripts/deploy/tasks/check_repos.py
@@ -237,7 +237,7 @@ class CheckReposTask(AbstractTask):
         # Do we have any warnings? If not, all checks for all repos were successful
         if not any([*self.warnings.values()]):  # No warnings = Success
             print_success(
-                f"Current commit: [bold]{workspace_friendly_name}[default] ({workspace_hash[:8]})\nYour local workspace is clean and up-to-date."
+                f"Current workspace hash: [bold]{workspace_friendly_name}[default] ({workspace_hash[:8]})\nYour local workspace is clean and up-to-date."
             )
             results = success(connections)
 
@@ -258,7 +258,7 @@ class CheckReposTask(AbstractTask):
                 warning_table.add_row(repo_name, f"{commit_name} ({commit_hash[:8]})", warnings)
             print_warning(
                 RichGroup(
-                    f"Current commit: [bold]{workspace_friendly_name}[default] ({workspace_hash[:8]})",
+                    f"Current workspace hash: [bold]{workspace_friendly_name}[default] ({workspace_hash[:8]})",
                     "Your local workspace is [bold][red]BAD!",
                     warning_table,
                     "Please check the warnings and decide if you want to proceed!",

--- a/scripts/deploy/tasks/check_repos.py
+++ b/scripts/deploy/tasks/check_repos.py
@@ -120,20 +120,24 @@ class OurRepo(Repo):
             return True
 
         print_debug(f"Repo {self}: Checking if behind: Comparing local and remote repository.")
-        ahead = False
-        for _ in self.iter_commits(f"{self.specified_branch}..{remote.name}/{self.specified_branch}"):
-            ahead = True
-        if ahead:
-            print_debug(f"Repo {self}: The local repository is ahead of the remote repository.")
-            self.warnings.append("The local repository is ahead of the remote repository.")
+        behind = len(list(self.iter_commits(f"{self.specified_branch}..{remote.name}/{self.specified_branch}")))
+        if behind:
+            print_debug(
+                f"Repo {self}: Your branch is behind the remote branch by {behind} commit{'s' if behind > 1 else ''}."
+            )
+            self.warnings.append(
+                f"Your branch is behind the remote branch by {behind} commit{'s' if behind > 1 else ''}."
+            )
 
         print_debug(f"Repo {self}: Checking if ahead: Comparing remote and local repository.")
-        behind = False
-        for _ in self.iter_commits(f"{remote.name}/{self.specified_branch}..{self.specified_branch}"):
-            behind = True
-        if behind:
-            print_debug(f"Repo {self}: The local repository is behind of the remote repository.")
-            self.warnings.append("The local repository is behind of the remote repository.")
+        ahead = len(list(self.iter_commits(f"{remote.name}/{self.specified_branch}..{self.specified_branch}")))
+        if ahead:
+            print_debug(
+                f"Repo {self}: Your branch is ahead of the remote branch by {ahead} commit{'s' if ahead > 1 else ''}."
+            )
+            self.warnings.append(
+                f"Your branch is ahead of the remote branch by {ahead} commit{'s' if ahead > 1 else ''}."
+            )
 
         return ahead or behind
 
@@ -255,7 +259,7 @@ class CheckReposTask(AbstractTask):
             print_warning(
                 RichGroup(
                     f"Current commit: [bold]{workspace_friendly_name}[default] ({workspace_hash[:8]})",
-                    "Your local workspace is [bold]BAD!",
+                    "Your local workspace is [bold][red]BAD!",
                     warning_table,
                     "Please check the warnings and decide if you want to proceed!",
                 )


### PR DESCRIPTION
# Summary
Fixes warnings, where ahead and behind were swapped.

## Proposed changes
- Fixes warnings, where ahead and behind were swapped.
- Log how many commits ahead or behind
- Always collect commit hashes and write to file, only skip workspace checks (a little bit time-consuming)

## Related issues
Closes #516 

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [X] Test on your machine
- [X] Test on the robot
- [ ] Create issues for future work
- [X] Triage this PR and label it
