### PR TITLE
Do not use same parameter in odom scaling

### DIFF
--- a/bitbots_navigation/bitbots_odometry/include/bitbots_odometry/motion_odometry.hpp
+++ b/bitbots_navigation/bitbots_odometry/include/bitbots_odometry/motion_odometry.hpp
@@ -51,7 +51,6 @@ class MotionOdometry : public rclcpp::Node {
   rclcpp::Time foot_change_time_{rclcpp::Time(0, 0, RCL_ROS_TIME)};
   std::string previous_support_link_;
   std::string current_support_link_;
-  rclcpp::Time start_time_;
 };
 
 }  // namespace bitbots_odometry

--- a/bitbots_navigation/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_navigation/bitbots_odometry/src/motion_odometry.cpp
@@ -103,13 +103,8 @@ void MotionOdometry::loop() {
     tf2::Transform current_support_to_base;
     tf2::fromMsg(current_support_to_base_msg.transform, current_support_to_base);
     double x = current_support_to_base.getOrigin().x();
-    if (current_odom_msg_.twist.twist.linear.x > 0) {
-      x = x * config_.x_forward_scaling;
-    } else {
-      x = x * config_.x_backward_scaling;
-    }
-    double y = current_support_to_base.getOrigin().y() * config_.y_scaling;
-    double yaw = tf2::getYaw(current_support_to_base.getRotation()) * config_.yaw_scaling;
+    double y = current_support_to_base.getOrigin().y();
+    double yaw = tf2::getYaw(current_support_to_base.getRotation());
     current_support_to_base.setOrigin({x, y, current_support_to_base.getOrigin().z()});
     tf2::Quaternion q;
     q.setRPY(0, 0, yaw);

--- a/bitbots_navigation/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_navigation/bitbots_odometry/src/motion_odometry.cpp
@@ -29,7 +29,6 @@ MotionOdometry::MotionOdometry()
   pub_odometry_ = this->create_publisher<nav_msgs::msg::Odometry>("motion_odometry", 1);
 
   previous_support_link_ = r_sole_frame_;
-  start_time_ = this->now();
 }
 
 void MotionOdometry::loop() {
@@ -37,7 +36,6 @@ void MotionOdometry::loop() {
   bitbots_utils::wait_for_tf(this->get_logger(), this->get_clock(), &tf_buffer_,
                              {base_link_frame_, r_sole_frame_, l_sole_frame_}, base_link_frame_);
 
-  rclcpp::Time cycle_start_time = this->now();
   config_ = param_listener_.get_params();
 
   // check if step finished, meaning left->right or right->left support. double support is skipped


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
We use the same parameter for scaling the transform from one foot to the other and the support foot to base.
This should not be the same scaling value.
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
We do not scale the transform from foot to base at all. Maybe sometimes the actual step sizes are bigger or smaller, so they can be scaled, but not like this.
## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Before the motion odometry was deleted, we already wanted to add this, but the PR was dropped.
## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
