### PR TITLE
feat(devcontainer): add `deploy_robots.py` aliases

### DIFF
--- a/scripts/ros.plugin.sh
+++ b/scripts/ros.plugin.sh
@@ -48,3 +48,8 @@ alias cca='cdc && colcon clean packages'
 alias sr="source /opt/ros/iron/setup.$shell && update_ros2_argcomplete"
 alias sc="source \$COLCON_WS/install/setup.$shell && update_ros2_argcomplete"
 alias sa='sr && sc'
+
+# deploy_robots tool aliases
+alias dp='$COLCON_WS/src/bitbots_main/scripts/deploy_robots.py --sync --build'
+alias dplo='dp --skip-local-repo-check'
+alias dpfull='dp --clean --install'

--- a/scripts/ros.plugin.sh
+++ b/scripts/ros.plugin.sh
@@ -50,6 +50,8 @@ alias sc="source \$COLCON_WS/install/setup.$shell && update_ros2_argcomplete"
 alias sa='sr && sc'
 
 # deploy_robots tool aliases
-alias dp='$COLCON_WS/src/bitbots_main/scripts/deploy_robots.py --sync --build'
+DEPLOY_ROBOTS = '$COLCON_WS/src/bitbots_main/scripts/deploy_robots.py'
+alias dp='$DEPLOY_ROBOTS --sync --build --print-bit-bot'
+alias dpfull='dp --install --configure'
+alias dpclean='dp --clean'
 alias dplo='dp --skip-local-repo-check'
-alias dpfull='dp --clean --install'


### PR DESCRIPTION
# Summary
Adds aliases to `scripts/ros.plugin.sh`, which is loaded by the devcontainer
and can also by used personally, by sourcing it in your shell.

## Checklist

- [x] Run `colcon build`
- [x] Test on your machine
- [x] Test on the robot
- [x] Triage this PR and label it
