### PR TITLE
Fix HCM hardware error detection

### DIFF
--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm.dsd
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm.dsd
@@ -5,7 +5,7 @@ $StartHCM
         NO --> @RobotStateStartup, @Wait + time:1 + r:false, @PlayAnimationStartup, @PlayAnimationDynup + direction:walkready + r:false
     RUNNING --> $CheckMotors
         MOTORS_NOT_STARTED --> @RobotStateStartup, @Wait
-        OVERLOAD --> @RobotStateMotorOff, @CancelGoals, @StopWalking, @PlayAnimationFallingFront, @TurnMotorsOff, @Wait
+        OVERLOAD --> @RobotStateMotorOff, @CancelGoals, @StopWalking, @PlayAnimationFallingFront, @Wait + time:1 + r:false, @TurnMotorsOff, @Wait
         PROBLEM --> @RobotStateHardwareProblem, @WaitForMotors
         TURN_ON --> @TurnMotorsOn, @PlayAnimationDynup + direction:walkready + r:false, @Wait
         OKAY --> $RecordAnimation

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/humanoid_control_module.py
@@ -147,14 +147,14 @@ class HardwareControlManager:
         """Updates the diagnostic state."""
         status: DiagnosticStatus
         for status in msg.status:
-            if "//Servos/" in status.name:
+            if "/Servos/" in status.name:
                 if status.level == DiagnosticStatus.ERROR and "Overload" in status.message:
                     self.blackboard.servo_overload = True
-            elif "//Servos" in status.name:
+            elif "/Servos" in status.name:
                 self.blackboard.servo_diag_error = status.level in (DiagnosticStatus.ERROR, DiagnosticStatus.STALE)
-            elif "//IMU" in status.name:
+            elif "/IMU" in status.name:
                 self.blackboard.imu_diag_error = status.level in (DiagnosticStatus.ERROR, DiagnosticStatus.STALE)
-            elif "//Pressure" in status.name:
+            elif "/Pressure" in status.name:
                 self.blackboard.pressure_diag_error = status.level in (DiagnosticStatus.ERROR, DiagnosticStatus.STALE)
 
     def get_state(self) -> RobotControlState:


### PR DESCRIPTION
# Summary
Due to a namespace change, the HCM hardware error detection was broken. 
Also, the motors were turned off too fast when we throw ourselves to the front in case of an overload error.

Now the hardware errors are shown correctly using the LEDs if we e.g. unplug a motor.

## Checklist

- [x] Run `colcon build`
- [x] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [x] Create issues for future work
- [x] Triage this PR and label it
