### PR TITLE
fix(devcontainer): correctly quote vars in aliases

### DIFF
--- a/scripts/ros.plugin.sh
+++ b/scripts/ros.plugin.sh
@@ -50,7 +50,7 @@ alias sc="source \$COLCON_WS/install/setup.$shell && update_ros2_argcomplete"
 alias sa='sr && sc'
 
 # deploy_robots tool aliases
-DEPLOY_ROBOTS = '$COLCON_WS/src/bitbots_main/scripts/deploy_robots.py'
+DEPLOY_ROBOTS="$COLCON_WS/src/bitbots_main/scripts/deploy_robots.py"
 alias dp='$DEPLOY_ROBOTS --sync --build --print-bit-bot'
 alias dpfull='dp --install --configure'
 alias dpclean='dp --clean'


### PR DESCRIPTION
# Summary
Due to the `DEPLOY_ROBOTS` variable using its own variable, but not being double quoted it was not working as intended.

## Checklist

- [x] Run `colcon build`
- [x] Test on your machine
- [x] Test on the robot
- [x] Triage this PR and label it
