### PR TITLE
ros_control: fix power status change after button press

### DIFF
--- a/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/core_hardware_interface.hpp
+++ b/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/core_hardware_interface.hpp
@@ -28,6 +28,7 @@ class CoreHardwareInterface : public bitbots_ros_control::HardwareInterface {
   void read(const rclcpp::Time &t, const rclcpp::Duration &dt);
 
   void write(const rclcpp::Time &t, const rclcpp::Duration &dt);
+  void restoreAfterPowerCycle();
 
  private:
   rclcpp::Node::SharedPtr nh_;

--- a/bitbots_lowlevel/bitbots_ros_control/src/core_hardware_interface.cpp
+++ b/bitbots_lowlevel/bitbots_ros_control/src/core_hardware_interface.cpp
@@ -149,4 +149,7 @@ void CoreHardwareInterface::write(const rclcpp::Time &t, const rclcpp::Duration 
     driver_->writeRegister(id_, "Power", requested_power_status_);
   }
 }
+
+void CoreHardwareInterface::restoreAfterPowerCycle() { requested_power_status_ = true; }
+
 }  // namespace bitbots_ros_control


### PR DESCRIPTION
# Summary
After the red button is pressed, the power cannot be restored with the switch. This PR fixes the behavior by resetting the requested power status after a power cycle.

## Checklist
- [x] Run `colcon build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
