### PR TITLE
ros_control: increase startup time afte power cycle to handle IMU boot

### DIFF
--- a/bitbots_lowlevel/bitbots_ros_control/config/wolfgang.yaml
+++ b/bitbots_lowlevel/bitbots_ros_control/config/wolfgang.yaml
@@ -1,6 +1,7 @@
 wolfgang_hardware_interface:
   ros__parameters:
     control_loop_hz: 500.0
+    start_delay: 2.0 # delay after the motor power is turned on until values are written, in seconds
 
     port_info:
       port0:
@@ -37,7 +38,6 @@ wolfgang_hardware_interface:
       auto_torque: true
 
       set_ROM_RAM: true # set the following values on startup to all motors
-      start_delay: 0.5 # delay after the motors are turned on until values are written, in seconds
 
       ROM_RAM_DEFAULT:
         # all names of parameters have to be the same as on the dynamixel table (see dynamixel_workbench_toolbox/src/dynamixel_item.cpp )

--- a/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/wolfgang_hardware_interface.hpp
+++ b/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/wolfgang_hardware_interface.hpp
@@ -33,8 +33,8 @@ class WolfgangHardwareInterface {
   std::vector<std::vector<std::shared_ptr<bitbots_ros_control::HardwareInterface>>> interfaces_;
   DynamixelServoHardwareInterface servo_interface_;
   rclcpp::Publisher<bitbots_msgs::msg::Audio>::SharedPtr speak_pub_;
-  std::optional<rclcpp::Time> motor_start_time_;
-  bool motor_first_write_{false};
+  std::optional<rclcpp::Time> bus_start_time_;
+  bool bus_first_write_{false};
 
   // prevent unnecessary error when power is turned on
   bool first_ping_error_;

--- a/bitbots_lowlevel/bitbots_ros_control/src/wolfgang_hardware_interface.cpp
+++ b/bitbots_lowlevel/bitbots_ros_control/src/wolfgang_hardware_interface.cpp
@@ -302,17 +302,17 @@ void threaded_write(const std::vector<std::shared_ptr<HardwareInterface>> &port_
 void WolfgangHardwareInterface::write(const rclcpp::Time &t, const rclcpp::Duration &dt) {
   if (core_present_ && !last_power_status_ && current_power_status_ &&
       nh_->get_parameter("servos.set_ROM_RAM").as_bool()) {
-    motor_start_time_ = t + rclcpp::Duration::from_seconds(nh_->get_parameter("servos.start_delay").as_double());
-    motor_first_write_ = true;
+    bus_start_time_ = t + rclcpp::Duration::from_seconds(nh_->get_parameter("start_delay").as_double());
+    bus_first_write_ = true;
   }
-  if (!motor_start_time_ || t > motor_start_time_.value()) {
-    if (motor_first_write_) {
+  if (!bus_start_time_ || t > bus_start_time_.value()) {
+    if (bus_first_write_) {
       for (std::vector<std::shared_ptr<HardwareInterface>> &port_interfaces : interfaces_) {
         for (std::shared_ptr<HardwareInterface> interface : port_interfaces) {
           interface->restoreAfterPowerCycle();
         }
       }
-      motor_first_write_ = false;
+      bus_first_write_ = false;
     }
     if (core_present_ && !current_power_status_) {
       // if power is off only write CORE


### PR DESCRIPTION
# Summary
Follow-up on #518, the IMU needs more time than 0.5 seconds. The variable names are also changed to reflect that it does not only influence the motors.

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
