### PR TITLE
pose_check.py: go to init in the end

### DIFF
--- a/bitbots_lowlevel/bitbots_ros_control/scripts/pose_check.py
+++ b/bitbots_lowlevel/bitbots_ros_control/scripts/pose_check.py
@@ -379,6 +379,7 @@ def main():
             f"{Style.BRIGHT}Press enter to continue.{Style.RESET_ALL}"
         )
 
+        move_to_joint_position(pub, {})
         print(
             f"\n\n{Fore.GREEN}If you have reached this point, the robot is hopefully in good shape and ready to go! GLHF"
         )


### PR DESCRIPTION
# Summary
I removed it accidentally in #519.

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
