### PR TITLE
ros_control: respect urdf joint limits

### DIFF
--- a/bitbots_lowlevel/bitbots_ros_control/CMakeLists.txt
+++ b/bitbots_lowlevel/bitbots_ros_control/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(controller_manager REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(dynamixel_workbench_toolbox REQUIRED)
 find_package(hardware_interface REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(moveit_ros_planning REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(realtime_tools REQUIRED)
@@ -60,6 +62,8 @@ ament_target_dependencies(
   diagnostic_msgs
   dynamixel_workbench_toolbox
   hardware_interface
+  moveit_core
+  moveit_ros_planning
   pluginlib
   rclcpp
   realtime_tools

--- a/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/dynamixel_servo_hardware_interface.hpp
+++ b/bitbots_lowlevel/bitbots_ros_control/include/bitbots_ros_control/dynamixel_servo_hardware_interface.hpp
@@ -70,6 +70,8 @@ class DynamixelServoHardwareInterface : public bitbots_ros_control::HardwareInte
   unsigned int joint_count_;
 
   std::vector<std::string> joint_names_;
+  std::vector<double> lower_joint_limits_;
+  std::vector<double> upper_joint_limits_;
 
   std::vector<double> goal_position_;
   std::vector<double> goal_effort_;

--- a/bitbots_wolfgang/wolfgang_description/urdf/robot.urdf
+++ b/bitbots_wolfgang/wolfgang_description/urdf/robot.urdf
@@ -2228,7 +2228,7 @@
     <axis xyz="-0.0 1.0 -0.0"/>
     <parent link="r_hip_2"/>
     <child link="r_upper_leg"/>
-    <limit effort="10" lower="-2.77" upper="0.87" velocity="5.76"/>
+    <limit effort="10" lower="-2.77" upper="0.79" velocity="5.76"/>
     <dynamics damping="1.23" friction="2.55"/>
   </joint>
   <joint name="RHipRoll" type="revolute">
@@ -3377,7 +3377,7 @@
     <axis xyz="7.95491e-17 -3.00167e-16 -1.0"/>
     <parent link="l_hip_2"/>
     <child link="l_upper_leg"/>
-    <limit effort="10" lower="-0.87" upper="2.77" velocity="5.76"/>
+    <limit effort="10" lower="-0.79" upper="2.77" velocity="5.76"/>
     <dynamics damping="1.23" friction="2.55"/>
   </joint>
   <joint name="LHipRoll" type="revolute">

--- a/bitbots_wolfgang/wolfgang_description/urdf/robot.urdf
+++ b/bitbots_wolfgang/wolfgang_description/urdf/robot.urdf
@@ -724,7 +724,7 @@
     <axis xyz="0.0 0.0 1.0"/>
     <parent link="r_upper_arm"/>
     <child link="r_lower_arm"/>
-    <limit effort="7.3" lower="-1.0472" upper="1.5708" velocity="8.17"/>
+    <limit effort="7.3" lower="-0.78" upper="1.5708" velocity="8.17"/>
     <dynamics damping="0.65" friction="1.73"/>
   </joint>
   <joint name="RShoulderRoll" type="revolute">
@@ -732,7 +732,7 @@
     <axis xyz="-0.0 -0.0 -1.0"/>
     <parent link="r_shoulder"/>
     <child link="r_upper_arm"/>
-    <limit effort="7.3" lower="0.0" upper="3.14159" velocity="8.17"/>
+    <limit effort="7.3" lower="-0.12" upper="3.1416" velocity="8.17"/>
     <dynamics damping="0.65" friction="1.73"/>
   </joint>
   <joint name="RShoulderPitch" type="revolute">
@@ -1079,7 +1079,7 @@
     <axis xyz="0.0 0.0 1.0"/>
     <parent link="l_upper_arm"/>
     <child link="l_lower_arm"/>
-    <limit effort="7.3" lower="-1.5708" upper="1.0472" velocity="8.17"/>
+    <limit effort="7.3" lower="-1.5708" upper="0.78" velocity="8.17"/>
     <dynamics damping="0.65" friction="1.73"/>
   </joint>
   <joint name="LShoulderRoll" type="revolute">
@@ -1087,7 +1087,7 @@
     <axis xyz="-0.0 -0.0 -1.0"/>
     <parent link="l_shoulder"/>
     <child link="l_upper_arm"/>
-    <limit effort="7.3" lower="-3.14159" upper="0.0" velocity="8.17"/>
+    <limit effort="7.3" lower="-3.1416" upper="0.12" velocity="8.17"/>
     <dynamics damping="0.65" friction="1.73"/>
   </joint>
   <joint name="LShoulderPitch" type="revolute">
@@ -2204,7 +2204,7 @@
     <axis xyz="0.0 -1.0 0.0"/>
     <parent link="r_ankle"/>
     <child link="r_foot"/>
-    <limit effort="10" lower="-0.63" upper="1.58" velocity="5.76"/>
+    <limit effort="10" lower="-1.4" upper="1.58" velocity="5.76"/>
     <dynamics damping="1.23" friction="2.55"/>
   </joint>
   <joint name="RAnklePitch" type="revolute">
@@ -2220,7 +2220,7 @@
     <axis xyz="-0.0 -1.0 -0.0"/>
     <parent link="r_upper_leg"/>
     <child link="r_lower_leg"/>
-    <limit effort="12.9" lower="-2.88" upper="0.0" velocity="3.87"/>
+    <limit effort="12.9" lower="-2.8" upper="0.2" velocity="3.87"/>
     <dynamics damping="2.92" friction="1.49"/>
   </joint>
   <joint name="RHipPitch" type="revolute">
@@ -2228,7 +2228,7 @@
     <axis xyz="-0.0 1.0 -0.0"/>
     <parent link="r_hip_2"/>
     <child link="r_upper_leg"/>
-    <limit effort="10" lower="-2.246" upper="0.9" velocity="5.76"/>
+    <limit effort="10" lower="-2.77" upper="0.87" velocity="5.76"/>
     <dynamics damping="1.23" friction="2.55"/>
   </joint>
   <joint name="RHipRoll" type="revolute">
@@ -2236,7 +2236,7 @@
     <axis xyz="-0.0 -0.0 -1.0"/>
     <parent link="r_hip_1"/>
     <child link="r_hip_2"/>
-    <limit effort="10" lower="-1.769" upper="0.871" velocity="5.76"/>
+    <limit effort="10" lower="-1.9" upper="1.6" velocity="5.76"/>
     <dynamics damping="1.23" friction="2.55"/>
   </joint>
   <joint name="RHipYaw" type="revolute">
@@ -3353,7 +3353,7 @@
     <axis xyz="-0.0 -1.0 -0.0"/>
     <parent link="l_ankle"/>
     <child link="l_foot"/>
-    <limit effort="10" lower="-1.58" upper="0.63" velocity="5.76"/>
+    <limit effort="10" lower="-1.58" upper="1.4" velocity="5.76"/>
     <dynamics damping="1.23" friction="2.55"/>
   </joint>
   <joint name="LAnklePitch" type="revolute">
@@ -3369,7 +3369,7 @@
     <axis xyz="-0.0 1.0 -0.0"/>
     <parent link="l_upper_leg"/>
     <child link="l_lower_leg"/>
-    <limit effort="12.9" lower="0" upper="2.88" velocity="3.87"/>
+    <limit effort="12.9" lower="-0.2" upper="2.8" velocity="3.87"/>
     <dynamics damping="2.92" friction="1.49"/>
   </joint>
   <joint name="LHipPitch" type="revolute">
@@ -3377,7 +3377,7 @@
     <axis xyz="7.95491e-17 -3.00167e-16 -1.0"/>
     <parent link="l_hip_2"/>
     <child link="l_upper_leg"/>
-    <limit effort="10" lower="-0.9" upper="2.246" velocity="5.76"/>
+    <limit effort="10" lower="-0.87" upper="2.77" velocity="5.76"/>
     <dynamics damping="1.23" friction="2.55"/>
   </joint>
   <joint name="LHipRoll" type="revolute">
@@ -3385,7 +3385,7 @@
     <axis xyz="-0.0 -0.0 -1.0"/>
     <parent link="l_hip_1"/>
     <child link="l_hip_2"/>
-    <limit effort="10" lower="-0.871" upper="1.769" velocity="5.76"/>
+    <limit effort="10" lower="-1.6" upper="1.9" velocity="5.76"/>
     <dynamics damping="1.23" friction="2.55"/>
   </joint>
   <joint name="LHipYaw" type="revolute">
@@ -3622,7 +3622,7 @@
     <axis xyz="-0.0 -0.0 1.0"/>
     <parent link="neck"/>
     <child link="head"/>
-    <limit effort="7.3" lower="-1.5708" upper="1.0472" velocity="8.17"/>
+    <limit effort="7.3" lower="-1.923" upper="1.24" velocity="8.17"/>
     <dynamics damping="0.65" friction="1.73"/>
   </joint>
   <joint name="HeadPan" type="revolute">


### PR DESCRIPTION
# Summary
Closes #268. This makes ros_control respect the joint limits in the URDF. The joint limits are also changed to reflect the physical limitations of the robot.

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
