### PR TITLE
do not consider network interfaces in the diagnostics 

### DIFF
--- a/bitbots_misc/system_monitor/config/config.yaml
+++ b/bitbots_misc/system_monitor/config/config.yaml
@@ -6,7 +6,7 @@ system_monitor:
     # These settings are quick_switches to completely disable certain parts of statistic collection
     do_cpu: true
     do_memory: true
-    do_network: true
+    do_network: false
 
     # these are the threshold values at which we start going into a warn state
     cpu_load_percentage: 80.0

--- a/bitbots_misc/system_monitor/system_monitor/monitor.py
+++ b/bitbots_misc/system_monitor/system_monitor/monitor.py
@@ -30,6 +30,7 @@ def main():
     node.declare_parameter("update_frequency", 10.0)
     node.declare_parameter("do_memory", True)
     node.declare_parameter("do_cpu", True)
+    node.declare_parameter("do_network", True)
     node.declare_parameter("cpu_load_percentage", 80.0)
     node.declare_parameter("memory_load_percentage", 80.0)
     node.declare_parameter("network_rate_received_errors", 10.0)
@@ -38,6 +39,7 @@ def main():
     rate = node.get_parameter("update_frequency").get_parameter_value().double_value
     do_memory = node.get_parameter("do_memory").get_parameter_value().bool_value
     do_cpu = node.get_parameter("do_cpu").get_parameter_value().bool_value
+    do_network = node.get_parameter("do_network").get_parameter_value().bool_value
     cpu_load_percentage = node.get_parameter("cpu_load_percentage").get_parameter_value().double_value
     memory_load_percentage = node.get_parameter("memory_load_percentage").get_parameter_value().double_value
     network_rate_received_errors = node.get_parameter("network_rate_received_errors").get_parameter_value().double_value
@@ -47,7 +49,7 @@ def main():
         last_send_time = time.time()
         running_processes, cpu_usages, overall_usage_percentage = cpus.collect_all() if do_cpu else (-1, [], 0)
         memory_available, memory_used, memory_total = memory.collect_all() if do_memory else (-1, -1, -1)
-        interfaces = network_interfaces.collect_all(node.get_clock())
+        interfaces = network_interfaces.collect_all(node.get_clock()) if do_network else []
 
         msg = WorkloadMsg(
             hostname=hostname,


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
Changed the "do_network" parameter to false and made sure that it is considered in the system monitor

## Proposed changes
<!--- Describe your changes and why they are necessary. -->
We get diagnostics errors if we unplug our ethernet connection to the robot. We do this in the beginning of every game. So we don't want to report this error. Therefore we want to ignore network diagnostics.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
