### PR TITLE
teamplayer.launch: Turn rosbag record off by default

### DIFF
--- a/bitbots_misc/bitbots_bringup/launch/teamplayer.launch
+++ b/bitbots_misc/bitbots_bringup/launch/teamplayer.launch
@@ -13,7 +13,7 @@
     <arg name="vision" default="true" description="Whether the vision system should be started" />
     <arg name="world_model" default="true" description="Whether the world model should be started"/>
     <arg name="monitoring" default="true" description="Whether the system monitor and udp bridge should be started" />
-    <arg name="record" default="true" description="Whether the ros bag recording should be started" />
+    <arg name="record" default="false" description="Whether the ros bag recording should be started" />
 
     <!-- load the global parameters -->
     <include file="$(find-pkg-share bitbots_parameter_blackboard)/launch/parameter_blackboard.launch">


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
Since the competition is over, we disable the rosbag recording again.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Reversal of #561 

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
