### PR TITLE
Let CI fail earlier if our server is down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ pull-files:
 	wget \
 		--no-verbose \
 		--show-progress \
+		--timeout=15 \
+		--tries=2 \
 		--recursive \
 		--timestamping \
 		--no-parent \
@@ -57,6 +59,8 @@ pull-files:
 	wget \
 		--no-verbose \
 		--show-progress \
+		--timeout=15 \
+		--tries=2 \
 		--recursive \
 		--timestamping \
 		--no-parent \


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
When our server is down, the wget commands in our CI job retry 20 times with a long timeout. This reduces the timeout to 15 seconds and the retries to 2. With that, our CI should fail much earlier. Also, this does not really harm the user running make install.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
