### PR TITLE
Fix foot step placement during rotation

### DIFF
--- a/bitbots_motion/bitbots_quintic_walk/src/walk_engine.cpp
+++ b/bitbots_motion/bitbots_quintic_walk/src/walk_engine.cpp
@@ -858,12 +858,23 @@ void WalkEngine::stepFromOrders(const std::vector<double>& linear_orders, double
   // No change in forward step and upward step
   tmp_diff.getOrigin()[0] = linear_orders[0];
   tmp_diff.getOrigin()[2] = linear_orders[2];
+
   // Add lateral foot offset
-  if (is_left_support_foot_) {
-    tmp_diff.getOrigin()[1] = config_.foot_distance;
-  } else {
-    tmp_diff.getOrigin()[1] = -1 * config_.foot_distance;
+  // This is normally just the foot distance, but if we turn we need to also move the foot forward/backward
+  geometry_msgs::msg::Vector3 foot_offset;
+  foot_offset.x = -sin(angular_z / 2) * config_.foot_distance;
+  foot_offset.y = cos(angular_z / 2) * config_.foot_distance;
+
+  // Invert lateral offset for right foot
+  if (!is_left_support_foot_) {
+    foot_offset.x *= -1;
+    foot_offset.y *= -1;
   }
+
+  // Add foot offset to step diff
+  tmp_diff.getOrigin()[0] += foot_offset.x;
+  tmp_diff.getOrigin()[1] += foot_offset.y;
+
   // Allow lateral step only on external foot
   //(internal foot will return to zero pose)
   if ((is_left_support_foot_ && linear_orders[1] > 0.0) || (!is_left_support_foot_ && linear_orders[1] < 0.0)) {


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
Adjust foot placement during rotations, so the feet pivot in both directions. Otherwise, one foot always stayed on the front and the other one on the back when the robot was rotating in place.  This lead to an instability along the diagonal axis.

## Examples
### New
![image](https://github.com/user-attachments/assets/e236fe6b-4896-4923-abaf-aa5fff6d8813)
![image](https://github.com/user-attachments/assets/e024d00c-c191-40cd-b224-5b931081d77e)

### Old
![image](https://github.com/user-attachments/assets/f95cccf4-e44f-4c6e-a15f-cb17fc1fdd30)
![image](https://github.com/user-attachments/assets/0e63990e-75db-4c1d-bc13-68febebd5a75)



## Proposed changes
Place the foot along a circle around the support foot so that it is an Asymptote angled with the target rotation divided by two.  We divide by two, because half of the offset is already present from the previous step.

## Checklist

- [x] Run `colcon build`
- [x] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [x] Create issues for future work
- [x] Triage this PR and label it
