### PR TITLE
Add service to Webots sim interface for pushing robot and client to Teleop script

### DIFF
--- a/bitbots_misc/bitbots_teleop/scripts/teleop_keyboard.py
+++ b/bitbots_misc/bitbots_teleop/scripts/teleop_keyboard.py
@@ -58,6 +58,13 @@ Head Modes:
 4: Ball Mode adapted for Penalty Kick
 5: Do a pattern which only looks in front of the robot
 
+Pushing:
+p: execute Push
+Shift-p: reset Power to 0
+ü/ä: increase/decrease power forward (x axis)
++/#: increase/decrease power left (y axis)
+SHIFT increases/decreases with factor 10
+
 CTRL-C to quit
 
 
@@ -122,7 +129,8 @@ class TeleopKeyboard(Node):
         self.th = 0
         self.status = 0
 
-        self.push_force = 100.0
+        self.push_force_x = 0.0
+        self.push_force_y = 0.0
 
         # Head Part
         self.create_subscription(JointState, "joint_states", self.joint_state_cb, 1)
@@ -313,10 +321,31 @@ class TeleopKeyboard(Node):
                     self.a_x = -1
                     self.th = 0
                 elif key == "p":
+                    # push robot in simulation
                     push_request = SimulatorPush.Request()
-                    push_request.force.x = self.push_force
+                    push_request.force.x = self.push_force_x
+                    push_request.force.y = self.push_force_y
                     push_request.relative = True
                     self.simulator_push.call_async(push_request)
+                elif key == "P":
+                    self.push_force_x = 0.0
+                    self.push_force_y = 0.0
+                elif key == "ü":
+                    self.push_force_x += 1
+                elif key == "Ü":
+                    self.push_force_x += 10
+                elif key == "ä":
+                    self.push_force_x -= 1
+                elif key == "Ä":
+                    self.push_force_x -= 10
+                elif key == "+":
+                    self.push_force_y += 1
+                elif key == "*":
+                    self.push_force_y += 10
+                elif key == "#":
+                    self.push_force_y -= 1
+                elif key == "'":
+                    self.push_force_y -= 10
                 else:
                     self.x = 0
                     self.y = 0
@@ -334,11 +363,12 @@ class TeleopKeyboard(Node):
                 twist.angular = Vector3(x=float(self.a_x), y=0.0, z=float(self.th))
                 self.pub.publish(twist)
                 state_str = (
-                    f"x:    {self.x}\n"
-                    f"y:    {self.y}\n"
-                    f"turn: {self.th}\n"
-                    f"head mode: {self.head_mode_msg.head_mode}\n"
-                    f"push force: {self.push_force}"
+                    f"x:    {self.x}     \n"
+                    f"y:    {self.y}     \n"
+                    f"turn: {self.th}     \n"
+                    f"head mode: {self.head_mode_msg.head_mode}     \n"
+                    f"push force x (+forward/-back): {self.push_force_x}     \n"
+                    f"push force y (+left/-right):   {self.push_force_y}     "
                 )
 
                 for _ in range(state_str.count("\n") + 1):

--- a/bitbots_msgs/CMakeLists.txt
+++ b/bitbots_msgs/CMakeLists.txt
@@ -50,6 +50,7 @@ rosidl_generate_interfaces(
   "srv/SetObjectPose.srv"
   "srv/SetObjectPosition.srv"
   "srv/SetTeachingMode.srv"
+  "srv/SimulatorPush.srv"
   DEPENDENCIES
   action_msgs
   geometry_msgs

--- a/bitbots_msgs/srv/SimulatorPush.srv
+++ b/bitbots_msgs/srv/SimulatorPush.srv
@@ -1,0 +1,4 @@
+geometry_msgs/Vector3 force
+bool relative
+string robot "amy"
+---

--- a/bitbots_simulation/bitbots_webots_sim/bitbots_webots_sim/webots_supervisor_controller.py
+++ b/bitbots_simulation/bitbots_webots_sim/bitbots_webots_sim/webots_supervisor_controller.py
@@ -8,7 +8,7 @@ from rclpy.time import Time
 from rosgraph_msgs.msg import Clock
 from std_srvs.srv import Empty
 
-from bitbots_msgs.srv import SetObjectPose, SetObjectPosition
+from bitbots_msgs.srv import SetObjectPose, SetObjectPosition, SimulatorPush
 
 G = 9.81
 
@@ -116,6 +116,9 @@ class SupervisorController:
             self.reset_ball_service = self.ros_node.create_service(Empty, base_ns + "reset_ball", self.reset_ball)
             self.set_ball_position_service = self.ros_node.create_service(
                 SetObjectPosition, base_ns + "set_ball_position", self.ball_pos_callback
+            )
+            self.simulator_push_service = self.ros_node.create_service(
+                SimulatorPush, base_ns + "simulator_push", self.simulator_push
             )
 
         self.world_info = self.supervisor.getFromDef("world_info")
@@ -239,6 +242,10 @@ class SupervisorController:
             request.object_name,
         )
         return response or SetObjectPose.Response()
+
+    def simulator_push(self, request=None, response=None):
+        self.robot_nodes[request.robot].addForce([request.force.x, request.force.y, request.force.z], request.relative)
+        return response or Empty.Response()
 
     def reset_ball(self, request=None, response=None):
         self.ball.getField("translation").setSFVec3f([0, 0, 0.0772])


### PR DESCRIPTION
# Summary
This pull request adds a new service type to bitbots_msgs and implements it in the webots simulation interface and the teleop script.
The service allows to add a force to the robot repeatably to test e.g. robustness of stabilization or walking

## Checklist

- [x] Run `colcon build`
- [x] Write documentation
- [x] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
