### PR TITLE
Fix pybullet sim package.xml leading to warning during build

### DIFF
--- a/bitbots_simulation/bitbots_pybullet_sim/package.xml
+++ b/bitbots_simulation/bitbots_pybullet_sim/package.xml
@@ -27,6 +27,7 @@
   <depend>python3-numpy</depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
     <bitbots_documentation>
       <status>unknown</status>
       <language>python</language>


### PR DESCRIPTION
As noticed in #628 

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
