### PR TITLE
Account for measurement delay in localization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -214,7 +214,8 @@
         "regex": "cpp",
         "future": "cpp",
         "*.ipp": "cpp",
-        "span": "cpp"
+        "span": "cpp",
+        "ranges": "cpp"
     },
     // Tell the ROS extension where to find the setup.bash
     // This also utilizes the COLCON_WS environment variable, which needs to be set

--- a/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/decisions/ball_kick_area.py
+++ b/bitbots_behavior/bitbots_body_behavior/bitbots_body_behavior/behavior_dsd/decisions/ball_kick_area.py
@@ -25,6 +25,7 @@ class BallKickArea(AbstractDecisionElement):
         ball_position = self.blackboard.world_model.get_ball_position_uv()
 
         self.publish_debug_data("ball_position", {"u": ball_position[0], "v": ball_position[1]})
+        self.publish_debug_data("smoothing_close", f"{self.no_near_decisions} ({self.no_near_decisions / self.smoothing * 10}%)")
 
         # Check if the ball is in the enter area
         if 0 <= ball_position[0] <= self.kick_x_enter and 0 <= abs(ball_position[1]) <= self.kick_y_enter:

--- a/bitbots_behavior/bitbots_body_behavior/config/body_behavior.yaml
+++ b/bitbots_behavior/bitbots_body_behavior/config/body_behavior.yaml
@@ -146,7 +146,7 @@ body_behavior:
     dribble_ball_distance_threshold: 0.5
     dribble_kick_angle: 0.6
 
-    kick_decision_smoothing: 5.0
+    kick_decision_smoothing: 1.0
 
     ##################
     # costmap params #

--- a/bitbots_navigation/bitbots_localization/config/config.yaml
+++ b/bitbots_navigation/bitbots_localization/config/config.yaml
@@ -3,11 +3,8 @@ bitbots_localization:
     misc:
       init_mode: 0
       percentage_best_particles: 100
-      min_motion_linear: 0.0
-      min_motion_angular: 0.0
       max_motion_linear: 0.5
       max_motion_angular: 3.14
-      filter_only_with_motion: false
     ros:
       line_pointcloud_topic: 'line_mask_relative_pc'
       goal_topic: 'goals_simulated'

--- a/bitbots_navigation/bitbots_localization/config/config.yaml
+++ b/bitbots_navigation/bitbots_localization/config/config.yaml
@@ -8,7 +8,6 @@ bitbots_localization:
     ros:
       line_pointcloud_topic: 'line_mask_relative_pc'
       goal_topic: 'goals_simulated'
-      fieldboundary_topic: 'field_boundary_relative'
       particle_publishing_topic: 'pose_particles'
       debug_visualization: true
     particle_filter:
@@ -43,10 +42,6 @@ bitbots_localization:
         goal:
           factor: 0.0
           out_of_field_score: 0.0
-        field_boundary:
-          factor: 0.0
-          out_of_field_score: 0.0
       confidences:
         line_element: 0.01
         goal_element: 0.0
-        field_boundary_element: 0.0

--- a/bitbots_navigation/bitbots_localization/include/bitbots_localization/ObservationModel.hpp
+++ b/bitbots_navigation/bitbots_localization/include/bitbots_localization/ObservationModel.hpp
@@ -6,17 +6,15 @@
 #define BITBOTS_LOCALIZATION_OBSERVATIONMODEL_H
 
 #include <particle_filter/ParticleFilter.h>
+#include <tf2_ros/buffer.h>
 
 #include <bitbots_localization/RobotState.hpp>
 #include <bitbots_localization/map.hpp>
 #include <bitbots_localization/tools.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <soccer_vision_3d_msgs/msg/field_boundary.hpp>
 #include <soccer_vision_3d_msgs/msg/goalpost.hpp>
 #include <soccer_vision_3d_msgs/msg/goalpost_array.hpp>
-#include <soccer_vision_3d_msgs/msg/marking_array.hpp>
-#include <soccer_vision_3d_msgs/msg/marking_intersection.hpp>
 
 #include "localization_parameters.hpp"
 
@@ -31,8 +29,8 @@ class RobotPoseObservationModel : public particle_filter::ObservationModel<Robot
    * empty
    */
   RobotPoseObservationModel(std::shared_ptr<Map> map_lines, std::shared_ptr<Map> map_goals,
-                            std::shared_ptr<Map> map_field_boundary, const bitbots_localization::Params &config,
-                            const FieldDimensions &field_dimensions);
+                            const bitbots_localization::Params &config, const FieldDimensions &field_dimensions,
+                            std::shared_ptr<tf2_ros::Buffer> tf_buffer);
 
   /**
    *
@@ -45,15 +43,9 @@ class RobotPoseObservationModel : public particle_filter::ObservationModel<Robot
 
   void set_measurement_goalposts(sv3dm::msg::GoalpostArray measurement);
 
-  void set_measurement_field_boundary(sv3dm::msg::FieldBoundary measurement);
-
-  void set_measurement_markings(sv3dm::msg::MarkingArray measurement);
-
   std::vector<std::pair<double, double>> get_measurement_lines() const;
 
   std::vector<std::pair<double, double>> get_measurement_goals() const;
-
-  std::vector<std::pair<double, double>> get_measurement_field_boundary() const;
 
   double get_min_weight() const override;
 
@@ -68,17 +60,20 @@ class RobotPoseObservationModel : public particle_filter::ObservationModel<Robot
 
   // Measurements
   std::vector<std::pair<double, double>> last_measurement_lines_;
+  rclcpp::Time last_stamp_lines;
   std::vector<std::pair<double, double>> last_measurement_goal_;
-  std::vector<std::pair<double, double>> last_measurement_field_boundary_;
+  rclcpp::Time last_stamp_goals;
 
   // Reference to the maps for the different classes
   std::shared_ptr<Map> map_lines_;
   std::shared_ptr<Map> map_goals_;
-  std::shared_ptr<Map> map_field_boundary_;
 
   // Parameters
   bitbots_localization::Params config_;
   FieldDimensions field_dimensions_;
+
+  // TF Buffer, we need a reference to this to estimate how far the robot has moved since the last measurement
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
 };
 };  // namespace bitbots_localization
 

--- a/bitbots_navigation/bitbots_localization/include/bitbots_localization/ObservationModel.hpp
+++ b/bitbots_navigation/bitbots_localization/include/bitbots_localization/ObservationModel.hpp
@@ -29,8 +29,7 @@ class RobotPoseObservationModel : public particle_filter::ObservationModel<Robot
    * empty
    */
   RobotPoseObservationModel(std::shared_ptr<Map> map_lines, std::shared_ptr<Map> map_goals,
-                            const bitbots_localization::Params &config, const FieldDimensions &field_dimensions,
-                            std::shared_ptr<tf2_ros::Buffer> tf_buffer);
+                            const bitbots_localization::Params &config, const FieldDimensions &field_dimensions);
 
   /**
    *
@@ -43,9 +42,9 @@ class RobotPoseObservationModel : public particle_filter::ObservationModel<Robot
 
   void set_measurement_goalposts(sv3dm::msg::GoalpostArray measurement);
 
-  std::vector<std::pair<double, double>> get_measurement_lines() const;
+  const std::vector<std::pair<double, double>> get_measurement_lines() const;
 
-  std::vector<std::pair<double, double>> get_measurement_goals() const;
+  const std::vector<std::pair<double, double>> get_measurement_goals() const;
 
   double get_min_weight() const override;
 
@@ -53,16 +52,22 @@ class RobotPoseObservationModel : public particle_filter::ObservationModel<Robot
 
   bool measurements_available() override;
 
+  void set_movement_since_line_measurement(const tf2::Transform movement);
+  void set_movement_since_goal_measurement(const tf2::Transform movement);
+
  private:
   double calculate_weight_for_class(const RobotState &state,
                                     const std::vector<std::pair<double, double>> &last_measurement,
-                                    std::shared_ptr<Map> map, double element_weight) const;
+                                    std::shared_ptr<Map> map, double element_weight,
+                                    const tf2::Transform &movement_since_measurement) const;
 
   // Measurements
   std::vector<std::pair<double, double>> last_measurement_lines_;
-  rclcpp::Time last_stamp_lines;
   std::vector<std::pair<double, double>> last_measurement_goal_;
-  rclcpp::Time last_stamp_goals;
+
+  // Movement since last measurement
+  tf2::Transform movement_since_line_measurement_ = tf2::Transform::getIdentity();
+  tf2::Transform movement_since_goal_measurement_ = tf2::Transform::getIdentity();
 
   // Reference to the maps for the different classes
   std::shared_ptr<Map> map_lines_;
@@ -71,9 +76,6 @@ class RobotPoseObservationModel : public particle_filter::ObservationModel<Robot
   // Parameters
   bitbots_localization::Params config_;
   FieldDimensions field_dimensions_;
-
-  // TF Buffer, we need a reference to this to estimate how far the robot has moved since the last measurement
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
 };
 };  // namespace bitbots_localization
 

--- a/bitbots_navigation/bitbots_localization/include/bitbots_localization/RobotState.hpp
+++ b/bitbots_navigation/bitbots_localization/include/bitbots_localization/RobotState.hpp
@@ -7,6 +7,8 @@
 
 #include <particle_filter/ParticleFilter.h>
 #include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2/utils.h>
 
 #include <Eigen/Core>
 #include <bitbots_localization/tools.hpp>
@@ -25,9 +27,16 @@ class RobotState {
   /**
    * @param x Position of the robot.
    * @param y Position of the robot.
-   * @param T Orientaion of the robot in radians.
+   * @param T Orientation of the robot in radians.
    */
   RobotState(double x, double y, double T);
+
+  /**
+   * @brief Constructor for a robot state based on a tf2::Transform.
+   *
+   * @param transform Transform of the robots base_footprint in the map frame.
+   */
+  explicit RobotState(tf2::Transform transform);
 
   RobotState operator*(float factor) const;
 
@@ -62,6 +71,8 @@ class RobotState {
 
   visualization_msgs::msg::Marker renderMarker(std::string n_space, std::string frame, rclcpp::Duration lifetime,
                                                std_msgs::msg::ColorRGBA color, rclcpp::Time stamp) const;
+
+  tf2::Transform getTransform() const;
 
  private:
   double m_XPos;

--- a/bitbots_navigation/bitbots_localization/include/bitbots_localization/localization.hpp
+++ b/bitbots_navigation/bitbots_localization/include/bitbots_localization/localization.hpp
@@ -255,8 +255,8 @@ class Localization {
    * @param map map for this class
    * @param publisher ros publisher for the type visualization_msgs::msg::Marker
    */
-  void publish_debug_rating(std::vector<std::pair<double, double>> measurements, double scale, const char name[24],
-                            std::shared_ptr<Map> map,
+  void publish_debug_rating(const std::vector<std::pair<double, double>> &measurements, double scale,
+                            const char name[24], std::shared_ptr<Map> map,
                             rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr &publisher);
 
   /**

--- a/bitbots_navigation/bitbots_localization/include/bitbots_localization/localization.hpp
+++ b/bitbots_navigation/bitbots_localization/include/bitbots_localization/localization.hpp
@@ -179,7 +179,7 @@ class Localization {
   rclcpp::TimerBase::SharedPtr publishing_timer_;
 
   // Declare tf2 objects
-  std::unique_ptr<tf2_ros::Buffer> tfBuffer;
+  std::shared_ptr<tf2_ros::Buffer> tfBuffer;
   std::shared_ptr<tf2_ros::TransformListener> tfListener;
   std::shared_ptr<tf2_ros::TransformBroadcaster> br;
 
@@ -218,9 +218,6 @@ class Localization {
 
   // Keep track of the odometry transform in the last step
   geometry_msgs::msg::TransformStamped previousOdomTransform_;
-
-  // Flag that checks if the robot is moving
-  bool robot_moved = false;
 
   // Keep track of the number of filter steps
   int timer_callback_count_ = 0;

--- a/bitbots_navigation/bitbots_localization/include/bitbots_localization/localization.hpp
+++ b/bitbots_navigation/bitbots_localization/include/bitbots_localization/localization.hpp
@@ -47,7 +47,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <soccer_vision_3d_msgs/msg/field_boundary.hpp>
 #include <soccer_vision_3d_msgs/msg/goalpost_array.hpp>
 #include <std_msgs/msg/color_rgba.hpp>
 #include <std_srvs/srv/trigger.hpp>
@@ -111,12 +110,6 @@ class Localization {
   void GoalPostsCallback(const sv3dm::msg::GoalpostArray &msg);  // TODO
 
   /**
-   * Callback for the relative field boundary measurements
-   * @param msg Message containing the field boundary points.
-   */
-  void FieldboundaryCallback(const sv3dm::msg::FieldBoundary &msg);
-
-  /**
    * Resets the state distribution of the state space
    * @param distribution The type of the distribution
    */
@@ -158,17 +151,13 @@ class Localization {
   // Declare subscribers
   rclcpp::Subscription<sm::msg::PointCloud2>::SharedPtr line_point_cloud_subscriber_;
   rclcpp::Subscription<sv3dm::msg::GoalpostArray>::SharedPtr goal_subscriber_;
-  rclcpp::Subscription<sv3dm::msg::FieldBoundary>::SharedPtr fieldboundary_subscriber_;
-
   rclcpp::Subscription<gm::msg::PoseWithCovarianceStamped>::SharedPtr rviz_initial_pose_subscriber_;
 
   // Declare publishers
   rclcpp::Publisher<gm::msg::PoseWithCovarianceStamped>::SharedPtr pose_with_covariance_publisher_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pose_particles_publisher_;
-  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr lines_publisher_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr line_ratings_publisher_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr goal_ratings_publisher_;
-  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr fieldboundary_ratings_publisher_;
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr field_publisher_;
 
   // Declare services
@@ -179,8 +168,8 @@ class Localization {
   rclcpp::TimerBase::SharedPtr publishing_timer_;
 
   // Declare tf2 objects
-  std::shared_ptr<tf2_ros::Buffer> tfBuffer;
-  std::shared_ptr<tf2_ros::TransformListener> tfListener;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   std::shared_ptr<tf2_ros::TransformBroadcaster> br;
 
   // Declare particle filter components
@@ -201,7 +190,6 @@ class Localization {
   // Declare input message buffers
   sm::msg::PointCloud2 line_pointcloud_relative_;
   sv3dm::msg::GoalpostArray goal_posts_relative_;
-  sv3dm::msg::FieldBoundary fieldboundary_relative_;
 
   // Declare time stamps
   rclcpp::Time last_stamp_lines = rclcpp::Time(0);
@@ -225,7 +213,6 @@ class Localization {
   // Maps for the different measurement classes
   std::shared_ptr<Map> lines_;
   std::shared_ptr<Map> goals_;
-  std::shared_ptr<Map> field_boundary_;
 
   // RNG that is used for the different sampling steps
   particle_filter::CRandomNumberGenerator random_number_generator_;

--- a/bitbots_navigation/bitbots_localization/include/bitbots_localization/map.hpp
+++ b/bitbots_navigation/bitbots_localization/include/bitbots_localization/map.hpp
@@ -45,8 +45,8 @@ class Map {
 
   double get_occupancy(double x, double y);
 
-  std::pair<double, double> observationRelative(std::pair<double, double> observation, double stateX, double stateY,
-                                                double stateT);
+  std::pair<double, double> getObservationCoordinatesInMapFrame(std::pair<double, double> observation, double stateX,
+                                                                double stateY, double stateT);
 
   nav_msgs::msg::OccupancyGrid get_map_msg(std::string frame_id, int threshold = -1);
 

--- a/bitbots_navigation/bitbots_localization/src/ObservationModel.cpp
+++ b/bitbots_navigation/bitbots_localization/src/ObservationModel.cpp
@@ -23,7 +23,7 @@ double RobotPoseObservationModel::calculate_weight_for_class(
   double particle_weight_for_class;
   if (!last_measurement.empty()) {
     // Subtract (reverse) the movement from our state to get the hypothetical state at the time of the measurement
-    const RobotState state_at_measurement(state.getTransform() * movement_since_measurement);
+    const RobotState state_at_measurement(state.getTransform() * movement_since_measurement.inverse());
     // Get the ratings for for all points in the measurement based on the map
     const std::vector<double> ratings = map->Map::provideRating(state_at_measurement, last_measurement);
     // Take the average of the ratings (functional)

--- a/bitbots_navigation/bitbots_localization/src/RobotState.cpp
+++ b/bitbots_navigation/bitbots_localization/src/RobotState.cpp
@@ -11,6 +11,11 @@ RobotState::RobotState() : is_explorer_(false), m_XPos(0.0), m_YPos(0.0), m_SinT
 RobotState::RobotState(double x, double y, double T)
     : is_explorer_(false), m_XPos(x), m_YPos(y), m_SinTheta(sin(T)), m_CosTheta(cos(T)) {}
 
+RobotState::RobotState(tf2::Transform transform)
+    : is_explorer_(false), m_XPos(transform.getOrigin().x()), m_YPos(transform.getOrigin().y()) {
+  setTheta(tf2::getYaw(transform.getRotation()));
+}
+
 RobotState RobotState::operator*(float factor) const {
   RobotState newState;
   newState.m_XPos = m_XPos * factor;
@@ -119,4 +124,14 @@ visualization_msgs::msg::Marker RobotState::renderMarker(std::string n_space, st
 
   return msg;
 }
+
+tf2::Transform RobotState::getTransform() const {
+  tf2::Transform transform;
+  transform.setOrigin(tf2::Vector3(getXPos(), getYPos(), 0));
+  tf2::Quaternion q;
+  q.setRPY(0, 0, getTheta());
+  transform.setRotation(q);
+  return transform;
+}
+
 }  // namespace bitbots_localization

--- a/bitbots_navigation/bitbots_localization/src/map.cpp
+++ b/bitbots_navigation/bitbots_localization/src/map.cpp
@@ -57,7 +57,7 @@ std::vector<double> Map::provideRating(const RobotState &state,
     std::pair<double, double> lineRelative;
 
     // get rating per line
-    lineRelative = observationRelative(observation, state.getXPos(), state.getYPos(), state.getTheta());
+    lineRelative = getObservationCoordinatesInMapFrame(observation, state.getXPos(), state.getYPos(), state.getTheta());
     double occupancy = get_occupancy(lineRelative.first, lineRelative.second);
 
     rating.push_back(occupancy);
@@ -65,12 +65,12 @@ std::vector<double> Map::provideRating(const RobotState &state,
   return rating;
 }
 
-std::pair<double, double> Map::observationRelative(
-    std::pair<double, double> observation, double stateX, double stateY,
-    double stateT) {  // todo rename to a more correct name like observationonmap?
-  // transformes observation from particle to map (assumes particle is correct)
-  // input: obsservation relative in polar coordinates and particle
-  // output: hypothetical observation on map
+std::pair<double, double> Map::getObservationCoordinatesInMapFrame(std::pair<double, double> observation, double stateX,
+                                                                   double stateY, double stateT) {
+  // queries the Cartesian metric map coordinates for a given observation (in polar coordinates)
+  // taken relative to a given state (in Cartesian coordinates)
+  // Input: Observation coordinates in polar coordinates, state coordinates in Cartesian coordinates
+  // Output: Observation coordinates in Cartesian coordinates in the map frame
 
   // add theta and convert back to cartesian
   std::pair<double, double> observationWithTheta = polarToCartesian(observation.first + stateT, observation.second);
@@ -78,14 +78,6 @@ std::pair<double, double> Map::observationRelative(
   // add to particle
   std::pair<double, double> observationRelative =
       std::make_pair(stateX + observationWithTheta.first, stateY + observationWithTheta.second);
-
-  // alternativ:
-  // Thrun 6.32, seite 169
-  //  but both equivalent
-  // double xGlobal = stateX + observation.second * (cos(stateT + observation.first));
-  // double yGlobal = stateY + observation.second * (sin(stateT + observation.first));
-
-  // std::pair<double, double> observationRelative = std::make_pair(xGlobal, yGlobal);
 
   return observationRelative;  // in cartesian
 }

--- a/bitbots_navigation/bitbots_localization/src/parameters.yml
+++ b/bitbots_navigation/bitbots_localization/src/parameters.yml
@@ -29,10 +29,6 @@ bitbots_localization:
       type: string
       description: "Topic for the goal input messages"
       read_only: true
-    fieldboundary_topic:
-      type: string
-      description: "Topic for the field boundary input messages"
-      read_only: true
     particle_publishing_topic:
       type: string
       description: "Topic for the particle publishing messages"
@@ -190,17 +186,6 @@ bitbots_localization:
           description: "Score which is given to a measurement (e.g. projected goal post) if it is out of the field"
           validation:
             bounds<>: [0.0, 100.0]
-      field_boundary:
-        factor:
-          type: double
-          description: "Weighing how much the field boundary information is considered for the scoring of a particle"
-          validation:
-            bounds<>: [0.0, 1.0]
-        out_of_field_score:
-          type: double
-          description: "Score which is given to a measurement (e.g. projected field boundary segment) if it is out of the field"
-          validation:
-            bounds<>: [0.0, 100.0]
     confidences:
       line_element:
         type: double
@@ -210,10 +195,5 @@ bitbots_localization:
       goal_element:
         type: double
         description: "Confidence we have in each data point of the goal information. Meaning each projected goal post"
-        validation:
-          bounds<>: [0.0, 1.0]
-      field_boundary_element:
-        type: double
-        description: "Confidence we have in each data point of the field boundary information. Meaning each projected field boundary segment"
         validation:
           bounds<>: [0.0, 1.0]

--- a/bitbots_navigation/bitbots_localization/src/parameters.yml
+++ b/bitbots_navigation/bitbots_localization/src/parameters.yml
@@ -10,19 +10,9 @@ bitbots_localization:
       description: "Percentage of particles which are considered to be the best ones. These particles are used to calculate the pose estimate"
       validation:
         bounds<>: [0, 100]
-    min_motion_linear:
-      type: double
-      description: "Minimum linear motion (m/s) which is considered to be a movement. This is relevant if we want to deactivate the filter if no movement is detected"
-      validation:
-        gt_eq<>: [0.0]
     max_motion_linear:
       type: double
       description: "Maximum linear motion (m/s) which is considered to be a movement. Updates larger than this are deemed unrealistic and are ignored"
-      validation:
-        gt_eq<>: [0.0]
-    min_motion_angular:
-      type: double
-      description: "Minimum angular motion (rad/s) which is considered to be a movement. This is relevant if we want to deactivate the filter if no movement is detected"
       validation:
         gt_eq<>: [0.0]
     max_motion_angular:
@@ -30,9 +20,6 @@ bitbots_localization:
       description: "Maximum angular motion (rad/s) which is considered to be a movement. Updates larger than this are deemed unrealistic and are ignored"
       validation:
         gt_eq<>: [0.0]
-    filter_only_with_motion:
-      type: bool
-      description: "If true, the filter is only active if a movement is detected"
   ros:
     line_pointcloud_topic:
       type: string


### PR DESCRIPTION
# Summary
Until now we rated the current state of the localization particles always with a delayed measurement. The particles are moved using the odometry "instantly" and are therefore not where the localization expects them to be at a different place compared to when the measurement was taken. Therefore, particles that lag behind were preferred, as they better matched the observations, which were assumed to be also instantly. 

The solution is to store the observation timestamp and move all particles temporary back by the amount we have walked since the measurement, as determined by the odometry before rating them. This solution works also for multiple asynchronous measurement sources. 

I hope that this enables more aggressive path planning parameters with less oscillations, as the localization state is not delayed as much.

I also did some cleanup, like simplifying the motion model math significantly and removing the field boundary input (we never used it).

Here is a plot of the robots center of mass and the position estimated by the localization. It needs to be noted that the robot walks very fast and the vision had an artificial pipeline delay of 1 second to test the effectiveness of the approach:

![Screenshot from 2025-01-07 19-18-14](https://github.com/user-attachments/assets/8d0751a4-c58a-4515-9df9-b52c4f7c78ab)

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
