### PR TITLE
Fixed non-hcm dynup requests messing with standup.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -214,7 +214,8 @@
         "regex": "cpp",
         "future": "cpp",
         "*.ipp": "cpp",
-        "span": "cpp"
+        "span": "cpp",
+        "ranges": "cpp"
     },
     // Tell the ROS extension where to find the setup.bash
     // This also utilizes the COLCON_WS environment variable, which needs to be set

--- a/bitbots_motion/bitbots_dynup/include/bitbots_dynup/dynup_node.hpp
+++ b/bitbots_motion/bitbots_dynup/include/bitbots_dynup/dynup_node.hpp
@@ -116,6 +116,7 @@ class DynupNode {
   double start_time_ = 0;
   bool server_free_ = true;
   bool debug_ = false;
+  bool cancel_goal_ = false;
 
   // TF2 related things
   tf2_ros::Buffer tf_buffer_;

--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/play_animation.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/play_animation.py
@@ -231,6 +231,10 @@ class PlayAnimationDynup(AbstractHCMActionElement):
 
         goal = Dynup.Goal()
         goal.direction = self.direction
+        # This indicates that the goal is send from the hcm and therfore has prio,
+        # canceling other tasks. The published joint goals are also marked with this flag so they
+        # are handled differently in the HCM joint mutex
+        goal.from_hcm = True
         self.blackboard.dynup_action_current_goal = self.blackboard.dynup_action_client.send_goal_async(
             goal, feedback_callback=self.animation_feedback_cb
         )

--- a/bitbots_motion/bitbots_hcm/src/hcm.cpp
+++ b/bitbots_motion/bitbots_hcm/src/hcm.cpp
@@ -87,12 +87,15 @@ class HCM_CPP : public rclcpp::Node {
   }
 
   void dynup_callback(const bitbots_msgs::msg::JointCommand msg) {
-    if (current_state_ == bitbots_msgs::msg::RobotControlState::STARTUP ||
-        current_state_ == bitbots_msgs::msg::RobotControlState::GETTING_UP ||
-        current_state_ == bitbots_msgs::msg::RobotControlState::MOTOR_OFF ||
-        current_state_ == bitbots_msgs::msg::RobotControlState::PICKED_UP ||
-        current_state_ == bitbots_msgs::msg::RobotControlState::PENALTY ||
-        current_state_ == bitbots_msgs::msg::RobotControlState::RECORD ||
+    if (msg.from_hcm and (current_state_ == bitbots_msgs::msg::RobotControlState::STARTUP ||
+                          current_state_ == bitbots_msgs::msg::RobotControlState::GETTING_UP ||
+                          current_state_ == bitbots_msgs::msg::RobotControlState::MOTOR_OFF ||
+                          current_state_ == bitbots_msgs::msg::RobotControlState::PICKED_UP ||
+                          current_state_ == bitbots_msgs::msg::RobotControlState::PENALTY ||
+                          current_state_ == bitbots_msgs::msg::RobotControlState::CONTROLLABLE)) {
+      pub_controller_command_->publish(msg);
+    }
+    if (current_state_ == bitbots_msgs::msg::RobotControlState::RECORD ||
         current_state_ == bitbots_msgs::msg::RobotControlState::CONTROLLABLE) {
       pub_controller_command_->publish(msg);
     }

--- a/bitbots_msgs/action/Dynup.action
+++ b/bitbots_msgs/action/Dynup.action
@@ -9,6 +9,9 @@ string DIRECTION_RISE = "rise"
 string DIRECTION_DESCEND = "descend"
 string DIRECTION_WALKREADY = "walkready"
 
+# Requests from the HCM have higher prio and are published to a different topic
+bool from_hcm 
+
 ---
 # Result definition
 bool successful

--- a/bitbots_msgs/msg/JointCommand.msg
+++ b/bitbots_msgs/msg/JointCommand.msg
@@ -1,4 +1,8 @@
 std_msgs/Header header
+
+# Mark this message so it has prio
+bool from_hcm
+
 string[] joint_names
 float64[] positions
 


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->

## Proposed changes
<!--- Describe your changes and why they are necessary. -->
HCM requests now cancel all other dynup requests and joint goals from dynup are processed differently wether the goal they originate from was sent by HCM. This increases the robustness against non-HCM components calling dynup during standup.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [x] Run `colcon build`
- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [x] Triage this PR and label it
