### PR TITLE
deleate arm up part of t pose script

### DIFF
--- a/bitbots_lowlevel/bitbots_ros_control/scripts/pose_check.py
+++ b/bitbots_lowlevel/bitbots_ros_control/scripts/pose_check.py
@@ -126,37 +126,6 @@ def main():
             f"{Style.BRIGHT}Press enter to continue.{Style.RESET_ALL}"
         )
 
-        ################
-        # Arms-Up-Pose #
-        ################
-
-        step += 1
-        input(
-            f"\n{Fore.YELLOW}{num_to_emoji(step)}: The robot will now move {Style.BRIGHT}its arms up and its head to the right.{Style.RESET_ALL}\n"
-            f"{Style.BRIGHT}Press enter to move.{Style.RESET_ALL}"
-        )
-
-        move_to_joint_position(
-            pub,
-            {
-                "LElbow": -math.pi / 2,
-                "LShoulderRoll": -math.pi,
-                "RElbow": math.pi / 2,
-                "RShoulderRoll": math.pi,
-                "HeadPan": -math.pi / 2,
-            },
-        )
-
-        input(
-            f"{Style.BRIGHT}\nChecks:{Style.RESET_ALL}\n"
-            "- Check that all limbs are straight.\n"
-            "- Check that both arms are symmetrical.\n"
-            "- Check that the head looks 90 degrees to the right.\n"
-            "- Check that the head is horizontal.\n"
-            "- Check for backlash and loose parts.\n"
-            f"{Style.BRIGHT}Press enter to continue.{Style.RESET_ALL}"
-        )
-
         ##########################
         # Arms-To-The-Front-Pose #
         ##########################


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
As we added some side bumpers, the arms up pose throws an overload error. To prevent that, we removed that pose from the t pose script.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [x] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
