### PR TITLE
Fix monitoring_pc.launch: Launch lichtblick

### DIFF
--- a/bitbots_misc/bitbots_bringup/launch/monitoring_pc.launch
+++ b/bitbots_misc/bitbots_bringup/launch/monitoring_pc.launch
@@ -7,7 +7,7 @@
     <include file="$(find-pkg-share foxglove_bridge)/launch/foxglove_bridge_launch.xml" />
 
     <!-- start foxglove gui -->
-    <executable cmd="foxglove-studio --no-sandbox" name="foxglove-studio" output="screen"/>
+    <executable cmd="lichtblick --no-sandbox" name="lichtblick" output="screen"/>
 
     <!-- start dynamic_stack_decider_visualization dsd_gui -->
     <node pkg="dynamic_stack_decider_visualization" exec="dsd_gui" name="dsd_gui" output="screen" />


### PR DESCRIPTION
# Summary
monitoring_pc.launch still launched foxglove-studio instead of lichtblick

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
