### PR TITLE
Async/await and events executor in animation server

### DIFF
--- a/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/change_motor_power.py
+++ b/bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/change_motor_power.py
@@ -26,5 +26,5 @@ class TurnMotorsOff(AbstractChangeMotorPower):
         if not self.blackboard.visualization_active and not self.blackboard.simulation_active:
             req = SetBool.Request()
             req.data = False
-            self.blackboard.motor_switch_service.call(req)
+            self.blackboard.motor_switch_service.call_async(req)
         return self.pop()


### PR DESCRIPTION
# Summary

Use events executor in animation server. Due to the complex nature of an action server that is able to reject/cancel actions as well as the close communication with the hcm via service rpc calls this was not possible in a single threaded manner without the use of async and await. Which actually works great with ROS 2. Why is this not the default in the tutorials????? 

This change brings the resource utilization from 30% (idle) to 2-6% (while playing animations ). Also the latency when calling animations (e.g. during falling) seems much lower.

Somehow ROS2 async does not has a async sleep function (using ros time), so I needed to build my own based on https://github.com/ros2/rclpy/issues/1234.

I tested many scenarios where e.g. the hcm cancels an animation in simulation and it seems to work without deadlocks.


### Minor Updates:

* [`bitbots_motion/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/change_motor_power.py`](diffhunk://#diff-e364870274b3284c41ee9f17b4d804ef8a148b20fbb770318bcc03c2cc529421L29-R29): Updated the motor switch service call to use the asynchronous `call_async` method for better responsiveness.

## Related issues
#682 

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
