### PR TITLE
fix donna reacts to button pressed

### DIFF
--- a/bitbots_lowlevel/bitbots_buttons/src/button_node.cpp
+++ b/bitbots_lowlevel/bitbots_buttons/src/button_node.cpp
@@ -36,7 +36,6 @@ class ButtonNode : public rclcpp::Node {
 
     if (manual_penalty_mode_) {
       manual_penalize_client_ = this->create_client<bitbots_msgs::srv::ManualPenalize>("manual_penalize");
-      manual_penalty_mode_ = manual_penalize_client_->wait_for_service(3s);
     }
 
     foot_zero_client_ = this->create_client<std_srvs::srv::Empty>("set_foot_zero");


### PR DESCRIPTION
# Summary
Donna's buttons to penalize and unpenalize her didn't work when she was stated withe the teamplayer launch script.

## Proposed changes
We found a timeout in the button node that was to short for her and that shot of the manual penalize service. We deleted that line so that there is a error message printed if the penalize service isn't found.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Checklist

- [x ] Run `colcon build`
- [ ] Write documentation
- [ ] Test on your machine
- [x ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
