### PR TITLE
Make sure nodes are using sim time if running in sim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,8 @@ commands may use incompatible installations or incomplete environment state.
 - Reuse existing launch patterns and substitutions. Keep launch argument,
   parameter, topic, and namespace names consistent across launch files, config
   files, and node declarations.
+- When editing or creating launch files, consider whether there is a need for passing
+  through the `use_sim_time` parameter. Most packages should support simulation time.
 
 ## Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/bitbots_misc/bitbots_bringup/launch/highlevel.launch
+++ b/src/bitbots_misc/bitbots_bringup/launch/highlevel.launch
@@ -60,7 +60,9 @@
         </include>
     </group>
     <group if="$(var whistle_detector)">
-        <include file="$(find-pkg-share bitbots_whistle_detector)/launch/whistle_detector.launch"/>
+        <include file="$(find-pkg-share bitbots_whistle_detector)/launch/whistle_detector.launch">
+            <arg name="sim" value="$(var sim)"/>
+        </include>
     </group>
     <!-- launch localization or fake localization -->
     <group if="$(var localization)">

--- a/src/bitbots_misc/bitbots_diagnostic/launch/aggregator.launch
+++ b/src/bitbots_misc/bitbots_diagnostic/launch/aggregator.launch
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
 <launch>
+    <arg name="sim" default="false" description="Whether to use simulation time" />
+
     <node pkg="diagnostic_aggregator" exec="aggregator_node" args="--ros-args --log-level WARN">
         <param from="$(find-pkg-share bitbots_diagnostic)/config/analyzers.yaml" />
+        <param name="use_sim_time" value="$(var sim)" />
     </node>
 </launch>
 

--- a/src/bitbots_misc/bitbots_robot_description/launch/load_robot_description.launch
+++ b/src/bitbots_misc/bitbots_robot_description/launch/load_robot_description.launch
@@ -5,6 +5,7 @@
     <node name="robot_state_publisher" pkg="robot_state_publisher" exec="robot_state_publisher">
         <param name="publish_frequency" value="100.0"/>
         <param name="robot_description" value="$(command '$(find-exec xacro) $(find-pkg-share piplus_description)/urdf/pi_plus_22dof.urdf.xacro')"/>
+        <param name="use_sim_time" value="$(var sim)"/>
     </node>
 
     <include file="$(find-pkg-share bitbots_extrinsic_calibration)/launch/calibration.launch">

--- a/src/bitbots_misc/bitbots_whistle_detector/launch/whistle_detector.launch
+++ b/src/bitbots_misc/bitbots_whistle_detector/launch/whistle_detector.launch
@@ -1,4 +1,7 @@
 <launch>
+    <arg name="sim" default="false" description="Whether to use simulation time" />
+
     <node pkg="bitbots_whistle_detector" exec="whistle_detector" name="bitbots_whistle_detector" output="screen">
+        <param name="use_sim_time" value="$(var sim)" />
     </node>
 </launch>

--- a/src/lib/bitbots_tf_buffer/src/bitbots_tf_buffer.cpp
+++ b/src/lib/bitbots_tf_buffer/src/bitbots_tf_buffer.cpp
@@ -42,8 +42,14 @@ class Buffer {
     rcl_node_t *node_handle =
         static_cast<rcl_node_t *>(reinterpret_cast<void *>(node.attr("handle").attr("pointer").cast<size_t>()));
     const char *node_name = rcl_node_get_name(node_handle);
+
+    // inherit the use_sim_time parameter from the outer node
+    const bool use_sim_time = node.attr("get_parameter")("use_sim_time").attr("value").cast<bool>();
+    rclcpp::NodeOptions node_options;
+    node_options.parameter_overrides({rclcpp::Parameter("use_sim_time", use_sim_time)});
+
     // create node with name <python_node_name>_tf
-    node_ = std::make_shared<rclcpp::Node>((std::string(node_name) + "_tf").c_str());
+    node_ = std::make_shared<rclcpp::Node>((std::string(node_name) + "_tf").c_str(), node_options);
 
     // Get buffer duration from python duration
     auto duration =


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
Various nodes, especially the ones used internally by the custom transform buffers were not using sim time when running in sim. This almost surely has lead to various issues with additional transform errors that would not have happened IRL.


## Proposed changes
<!--- Describe your changes and why they are necessary. -->

I went through all nodes and made sure they use `use_sim_time=true` if in the correct context.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
