### PR TITLE
Remove -Werror on the robot

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -26,7 +26,7 @@ cmd = "colcon build --symlink-install --packages-skip zed_wrapper zed_components
 description = "Builds all ROS 2 packages. Add --packages-select <package names> to build specific packages."
 
 [feature.robot.tasks.build]
-cmd = "colcon build --symlink-install --cmake-args -G 'Unix Makefiles' -DCMAKE_C_FLAGS='-Wall -Wextra -Werror -Wno-error=pedantic' -DCMAKE_CXX_FLAGS='-Wall -Wextra -Wpedantic -Werror' "
+cmd = "colcon build --symlink-install --cmake-args -G 'Unix Makefiles' -DCMAKE_C_FLAGS='-Wall -Wextra -Wno-error=pedantic' -DCMAKE_CXX_FLAGS='-Wall -Wextra -Wpedantic' "
 description = "Builds all ROS 2 packages. Add --packages-select <package names> to build specific packages."
 
 [tasks.clean]


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->
The zed_components package on the robot produces a lot of warnings, some of them not in the files we are vendoring.

## Proposed changes
<!--- Describe your changes and why they are necessary. -->
This PR disables -Werror on the robot, keeping it active for the CI and PC builds. Those don't build zed_components so they work correctly

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
See #1027. I would suggest to not close that issue incase we ever want to tackle these warnings (some of them are absolutely relevant)

## Checklist

- [x] Run `pixi run build`
- [ ] ~~Write documentation~~
- [x] Test on your machine
- [x] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
