### PR TITLE
Default to MjViser

### DIFF
--- a/src/bitbots_misc/bitbots_bringup/launch/mujoco_simulation.launch.py
+++ b/src/bitbots_misc/bitbots_bringup/launch/mujoco_simulation.launch.py
@@ -115,6 +115,7 @@ def launch_setup(context):
     """Dynamically set up launches based on num_robots."""
     num_robots = int(LaunchConfiguration("num_robots").perform(context))
     robot_type = str(LaunchConfiguration("robot_type").perform(context))
+    use_web = LaunchConfiguration("web").perform(context).lower() == "true"
     package_share = get_package_share_directory("bitbots_mujoco_sim")
     bridge_config_dir = Path(package_share) / "config" / "domain_bridges"
 
@@ -139,7 +140,7 @@ def launch_setup(context):
             name="sim_interface",
             output="screen",
             emulate_tty=True,
-            parameters=[{"world_file": str(world_file)}],
+            parameters=[{"world_file": str(world_file), "web": use_web}],
         ),
     )
 
@@ -196,6 +197,11 @@ def generate_launch_description():
             default_value="piplus",
             description="Set the type of robot used (piplus, x02)",
         ),
+        DeclareLaunchArgument(
+            "web",
+            default_value="true",
+            description="Use web-based mjviser viewer instead of the native MuJoCo viewer",
+        )
     ]
 
     # Add all teamplayer arguments with empty default (means use teamplayer's default)

--- a/src/bitbots_misc/bitbots_bringup/launch/mujoco_simulation.launch.py
+++ b/src/bitbots_misc/bitbots_bringup/launch/mujoco_simulation.launch.py
@@ -201,7 +201,7 @@ def generate_launch_description():
             "web",
             default_value="true",
             description="Use web-based mjviser viewer instead of the native MuJoCo viewer",
-        )
+        ),
     ]
 
     # Add all teamplayer arguments with empty default (means use teamplayer's default)

--- a/src/bitbots_misc/bitbots_bringup/launch/simulator_teamplayer.launch
+++ b/src/bitbots_misc/bitbots_bringup/launch/simulator_teamplayer.launch
@@ -12,7 +12,7 @@
     <arg name="vision" default="true" description="Whether the vision system should be started" />
     <arg name="world_model" default="true" description="Whether the world model should be started"/>
     <arg name="rl_motion" default="true" description="Whether to use the RL motion system instead of the regular one" />
-    <arg name="web" default="false" description="Use web-based mjviser viewer instead of the native MuJoCo viewer"/>
+    <arg name="web" default="true" description="Use web-based mjviser viewer instead of the native MuJoCo viewer"/>
 
     <!-- load the general simulator -->
     <include file="$(find-pkg-share bitbots_mujoco_sim)/launch/simulator.launch" >


### PR DESCRIPTION
# Summary
<!--- Provide a general summary of the changes -->

As discussed in the meeting, this PR defaults the launch script(s) to use the viser frontend for MuJoCo by default.

From my personal testing running the simulator locally, the performance difference if it exists benefits Viser and not the native viewer. Since the native viewer also has a few limitations that Viser does not have default to the latter should not have any drawbacks. (ok, except that you manually need to open it up once)

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [x] Run `pixi run build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] ~~Test on the robot~~
- [ ] Create issues for future work
- [ ] Triage this PR and label it
