### PR TITLE
Reset the head_mover pitch to previous values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -108,6 +108,7 @@
         "rtype",
         "rviz",
         "samplerate",
+        "scanline",
         "scipy",
         "sdev",
         "seaborn",

--- a/src/bitbots_motion/bitbots_head_mover/config/head_config.yml
+++ b/src/bitbots_motion/bitbots_head_mover/config/head_config.yml
@@ -69,7 +69,7 @@ move_head:
 
       pitch_max:
         type: double_array
-        default_value: [-5.0, 35.0]
+        default_value: [20.0, 60.0]
         description: "Maximum pitch values for the search pattern (in degrees)"
         validation:
           fixed_size<>: 2
@@ -105,7 +105,7 @@ move_head:
 
       pitch_max:
         type: double_array
-        default_value: [-5.0, 35.0]
+        default_value: [20.0, 60.0]
         description: "Maximum pitch values for the search pattern (in degrees)"
         validation:
           fixed_size<>: 2
@@ -141,7 +141,7 @@ move_head:
 
       pitch_max:
         type: double_array
-        default_value: [-5.0, 35.0]
+        default_value: [20.0, 60.0]
         description: "Maximum pitch values for the search pattern (in degrees)"
         validation:
           fixed_size<>: 2
@@ -177,14 +177,14 @@ move_head:
 
       pitch_max:
         type: double_array
-        default_value: [0.0, 0.0]
+        default_value: [30.0, 30.0]
         description: "Maximum pitch values for the search pattern (in degrees)"
         validation:
           fixed_size<>: 2
 
       scan_lines:
         type: int
-        default_value: 2
+        default_value: 1
         description: "Number of scan horizontal lines for the search pattern"
         validation:
           gt_eq<>: [1]


### PR DESCRIPTION
Reset the head_mover pitch to previous values.
We don't have the camera angle offset plate anymore.

# Summary
<!--- Provide a general summary of the changes -->

## Proposed changes
<!--- Describe your changes and why they are necessary. -->

## Related issues
https://github.com/bit-bots/bitbots_main/pull/957/changes
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce. -->

## Checklist

- [ ] Run `pixi run build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Create issues for future work
- [ ] Triage this PR and label it
